### PR TITLE
add hset, hdel, hgetall, hget, hsetnx

### DIFF
--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -413,6 +413,30 @@ macro_rules! test_backend {
 
         #[tokio::test]
         #[serial]
+        async fn test_atomic_write_h_set_nx() {
+            let b = $f().await;
+
+            let mut tx = AtomicWriteOperation::new();
+            tx.set("foo", "bar");
+            let c = tx.h_set_nx("h", "foo", "bar");
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), true);
+            assert_eq!(c.failed(), false);
+
+            let v = b.get("foo").await.unwrap();
+            assert_eq!(v, Some("bar".into()));
+
+            let mut tx = AtomicWriteOperation::new();
+            tx.set("foo", "baz");
+            let c = tx.h_set_nx("h", "foo", "bar");
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), false);
+            assert_eq!(c.failed(), true);
+
+            let v = b.get("foo").await.unwrap();
+            assert_eq!(v, Some("bar".into()));
+        }
+
+        #[tokio::test]
+        #[serial]
         async fn test_atomic_write_h_del() {
             let b = $f().await;
 

--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -67,6 +67,51 @@ macro_rules! test_backend {
 
         #[tokio::test]
         #[serial]
+        async fn test_h_get() {
+            let b = $f().await;
+
+            let v = b.h_get("foo", "bar").await.unwrap();
+            assert_eq!(v, None);
+
+            b.h_set("foo", [("bar", "baz")].iter().cloned()).await.unwrap();
+
+            let v = b.h_get("foo", "bar").await.unwrap();
+            assert_eq!(Some("baz".into()), v);
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn test_h_del() {
+            let b = $f().await;
+
+            b.h_del("foo", ["bar"].iter().cloned()).await.unwrap();
+
+            b.h_set("foo", [("bar", "baz")].iter().cloned()).await.unwrap();
+
+            let v = b.h_get("foo", "bar").await.unwrap();
+            assert_eq!(Some("baz".into()), v);
+
+            b.h_del("foo", ["bar"].iter().cloned()).await.unwrap();
+
+            let v = b.h_get("foo", "bar").await.unwrap();
+            assert_eq!(v, None);
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn test_get_all() {
+            let b = $f().await;
+
+            b.h_set("foo", [("bar", "baz"), ("baz", "qux")].iter().cloned()).await.unwrap();
+
+            let m = b.h_get_all("foo").await.unwrap();
+            assert_eq!(m.len(), 2);
+            assert_eq!(Some(&"baz".into()), m.get("bar".as_bytes()));
+            assert_eq!(Some(&"qux".into()), m.get("baz".as_bytes()));
+        }
+
+        #[tokio::test]
+        #[serial]
         async fn test_z_range_by_score() {
             let b = $f().await;
 
@@ -340,6 +385,55 @@ macro_rules! test_backend {
 
             let members = b.s_members("set").await.unwrap();
             assert_eq!(vec!["bar"], members);
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn test_atomic_write_h_set() {
+            let b = $f().await;
+
+            b.set("setcond", "foo").await.unwrap();
+
+            let mut tx = AtomicWriteOperation::new();
+            let c = tx.set_nx("setcond", "foo");
+            tx.h_set("h", [("foo", "bar")].iter().cloned());
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), false);
+            assert_eq!(c.failed(), true);
+
+            let v = b.h_get("h", "foo").await.unwrap();
+            assert_eq!(v, None);
+
+            let mut tx = AtomicWriteOperation::new();
+            tx.h_set("h", [("foo", "bar")].iter().cloned());
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), true);
+
+            let v = b.h_get("h", "foo").await.unwrap();
+            assert_eq!(Some("bar".into()), v);
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn test_atomic_write_h_del() {
+            let b = $f().await;
+
+            b.set("setcond", "foo").await.unwrap();
+            b.h_set("h", [("foo", "bar")].iter().cloned()).await.unwrap();
+
+            let mut tx = AtomicWriteOperation::new();
+            let c = tx.set_nx("setcond", "foo");
+            tx.h_del("h", ["foo"].iter().cloned());
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), false);
+            assert_eq!(c.failed(), true);
+
+            let v = b.h_get("h", "foo").await.unwrap();
+            assert_eq!(Some("bar".into()), v);
+
+            let mut tx = AtomicWriteOperation::new();
+            tx.h_del("h", ["foo"].iter().cloned());
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), true);
+
+            let v = b.h_get("h", "foo").await.unwrap();
+            assert_eq!(v, None);
         }
     };
 }

--- a/src/dynstore.rs
+++ b/src/dynstore.rs
@@ -1,4 +1,5 @@
 use super::{dynamodbstore, memorystore, redisstore, Arg, AtomicWriteOperation, BatchOperation, Result, Value};
+use std::collections::HashMap;
 
 pub enum Backend {
     Memory(memorystore::Backend),
@@ -66,6 +67,42 @@ impl super::Backend for Backend {
             Self::Memory(backend) => backend.s_members(key).await,
             Self::Redis(backend) => backend.s_members(key).await,
             Self::DynamoDB(backend) => backend.s_members(key).await,
+        }
+    }
+
+    async fn h_set<'a, 'b, 'c, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send, I: IntoIterator<Item = (F, V)> + Send>(
+        &self,
+        key: K,
+        fields: I,
+    ) -> Result<()> {
+        match self {
+            Self::Memory(backend) => backend.h_set(key, fields).await,
+            Self::Redis(backend) => backend.h_set(key, fields).await,
+            Self::DynamoDB(backend) => backend.h_set(key, fields).await,
+        }
+    }
+
+    async fn h_del<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, I: IntoIterator<Item = F> + Send>(&self, key: K, fields: I) -> Result<()> {
+        match self {
+            Self::Memory(backend) => backend.h_del(key, fields).await,
+            Self::Redis(backend) => backend.h_del(key, fields).await,
+            Self::DynamoDB(backend) => backend.h_del(key, fields).await,
+        }
+    }
+
+    async fn h_get<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<Option<Value>> {
+        match self {
+            Self::Memory(backend) => backend.h_get(key, field).await,
+            Self::Redis(backend) => backend.h_get(key, field).await,
+            Self::DynamoDB(backend) => backend.h_get(key, field).await,
+        }
+    }
+
+    async fn h_get_all<'a, K: Into<Arg<'a>> + Send>(&self, key: K) -> Result<HashMap<Vec<u8>, Value>> {
+        match self {
+            Self::Memory(backend) => backend.h_get_all(key).await,
+            Self::Redis(backend) => backend.h_get_all(key).await,
+            Self::DynamoDB(backend) => backend.h_get_all(key).await,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ extern crate async_trait;
 extern crate serial_test;
 extern crate simple_error;
 
-use std::convert::From;
 use std::sync::mpsc;
+use std::{collections::HashMap, convert::From};
 
 pub mod backendtest;
 pub mod dynamodbstore;
@@ -150,6 +150,15 @@ pub trait Backend {
     async fn s_add<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()>;
     async fn s_members<'a, K: Into<Arg<'a>> + Send>(&self, key: K) -> Result<Vec<Value>>;
 
+    async fn h_set<'a, 'b, 'c, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send, I: IntoIterator<Item = (F, V)> + Send>(
+        &self,
+        key: K,
+        fields: I,
+    ) -> Result<()>;
+    async fn h_del<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, I: IntoIterator<Item = F> + Send>(&self, key: K, fields: I) -> Result<()>;
+    async fn h_get<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<Option<Value>>;
+    async fn h_get_all<'a, K: Into<Arg<'a>> + Send>(&self, key: K) -> Result<HashMap<Vec<u8>, Value>>;
+
     async fn z_add<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V, score: f64) -> Result<()>;
     async fn z_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize>;
     async fn z_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>>;
@@ -234,6 +243,8 @@ pub enum AtomicWriteSubOperation<'a> {
     DeleteXX(Arg<'a>, mpsc::SyncSender<bool>),
     SAdd(Arg<'a>, Arg<'a>),
     SRem(Arg<'a>, Arg<'a>),
+    HSet(Arg<'a>, Vec<(Arg<'a>, Arg<'a>)>),
+    HDel(Arg<'a>, Vec<Arg<'a>>),
 }
 
 // DynamoDB can't do more than 25 operations in an atomic write so all backends should enforce this
@@ -283,5 +294,21 @@ impl<'a> AtomicWriteOperation<'a> {
 
     pub fn s_rem<'k: 'a, 'v: 'a, K: Into<Arg<'k>> + Send, V: Into<Arg<'v>> + Send>(&mut self, key: K, value: V) {
         self.ops.push(AtomicWriteSubOperation::SRem(key.into(), value.into()));
+    }
+
+    pub fn h_set<'k: 'a, 'f: 'a, 'v: 'a, K: Into<Arg<'k>> + Send, F: Into<Arg<'f>> + Send, V: Into<Arg<'v>> + Send, I: IntoIterator<Item = (F, V)> + Send>(
+        &mut self,
+        key: K,
+        fields: I,
+    ) {
+        self.ops.push(AtomicWriteSubOperation::HSet(
+            key.into(),
+            fields.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
+        ));
+    }
+
+    pub fn h_del<'k: 'a, 'f: 'a, K: Into<Arg<'k>> + Send, F: Into<Arg<'f>> + Send, I: IntoIterator<Item = F> + Send>(&mut self, key: K, fields: I) {
+        self.ops
+            .push(AtomicWriteSubOperation::HDel(key.into(), fields.into_iter().map(|k| k.into()).collect()));
     }
 }

--- a/src/redisstore.rs
+++ b/src/redisstore.rs
@@ -1,7 +1,7 @@
 use super::{Arg, AtomicWriteOperation, AtomicWriteSubOperation, BatchOperation, BatchSubOperation, Result, Value, MAX_ATOMIC_WRITE_SUB_OPERATIONS};
 use redis::{aio::Connection, AsyncCommands, Client, FromRedisValue, RedisResult, RedisWrite, Script, ToRedisArgs};
 use simple_error::SimpleError;
-use std::sync::mpsc;
+use std::{collections::HashMap, sync::mpsc};
 
 pub struct Backend {
     pub client: Client,
@@ -94,6 +94,28 @@ impl super::Backend for Backend {
         Ok(self.get_connection().await?.smembers(key.into()).await?)
     }
 
+    async fn h_set<'a, 'b, 'c, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send, I: IntoIterator<Item = (F, V)> + Send>(
+        &self,
+        key: K,
+        fields: I,
+    ) -> Result<()> {
+        let fields: Vec<_> = fields.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        Ok(self.get_connection().await?.hset_multiple(key.into(), &fields).await?)
+    }
+
+    async fn h_del<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, I: IntoIterator<Item = F> + Send>(&self, key: K, fields: I) -> Result<()> {
+        let fields: Vec<_> = fields.into_iter().map(|f| f.into()).collect();
+        Ok(self.get_connection().await?.hdel(key.into(), fields).await?)
+    }
+
+    async fn h_get<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<Option<Value>> {
+        Ok(self.get_connection().await?.hget(key.into(), field.into()).await?)
+    }
+
+    async fn h_get_all<'a, K: Into<Arg<'a>> + Send>(&self, key: K) -> Result<HashMap<Vec<u8>, Value>> {
+        Ok(self.get_connection().await?.hgetall(key.into()).await?)
+    }
+
     async fn z_add<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V, score: f64) -> Result<()> {
         Ok(self.get_connection().await?.zadd(key.into(), value.into(), score).await?)
     }
@@ -172,7 +194,7 @@ impl super::Backend for Backend {
         struct SubOp<'a> {
             key: Arg<'a>,
             condition: &'static str,
-            write: &'static str,
+            write: String,
             args: Vec<Arg<'a>>,
             failure_tx: Option<mpsc::SyncSender<bool>>,
         }
@@ -184,59 +206,89 @@ impl super::Backend for Backend {
                 AtomicWriteSubOperation::Set(key, value) => SubOp {
                     key,
                     condition: "true",
-                    write: "redis.call('set', $@, $0)",
+                    write: "redis.call('set', $@, $0)".to_string(),
                     args: vec![value],
                     failure_tx: None,
                 },
                 AtomicWriteSubOperation::SetNX(key, value, tx) => SubOp {
                     key,
                     condition: "redis.call('exists', $@) == 0",
-                    write: "redis.call('set', $@, $0)",
+                    write: "redis.call('set', $@, $0)".to_string(),
                     args: vec![value],
                     failure_tx: Some(tx),
                 },
                 AtomicWriteSubOperation::Delete(key) => SubOp {
                     key,
                     condition: "true",
-                    write: "redis.call('del', $@)",
+                    write: "redis.call('del', $@)".to_string(),
                     args: vec![],
                     failure_tx: None,
                 },
                 AtomicWriteSubOperation::DeleteXX(key, tx) => SubOp {
                     key,
                     condition: "redis.call('exists', $@) == 1",
-                    write: "redis.call('del', $@)",
+                    write: "redis.call('del', $@)".to_string(),
                     args: vec![],
                     failure_tx: Some(tx),
                 },
                 AtomicWriteSubOperation::SAdd(key, value) => SubOp {
                     key,
                     condition: "true",
-                    write: "redis.call('sadd', $@, $0)",
+                    write: "redis.call('sadd', $@, $0)".to_string(),
                     args: vec![value],
                     failure_tx: None,
                 },
                 AtomicWriteSubOperation::SRem(key, value) => SubOp {
                     key,
                     condition: "true",
-                    write: "redis.call('srem', $@, $0)",
+                    write: "redis.call('srem', $@, $0)".to_string(),
                     args: vec![value],
                     failure_tx: None,
                 },
                 AtomicWriteSubOperation::ZAdd(key, value, score) => SubOp {
                     key,
                     condition: "true",
-                    write: "redis.call('zadd', $@, $1, $0)",
+                    write: "redis.call('zadd', $@, $1, $0)".to_string(),
                     args: vec![value, score.to_string().into()],
                     failure_tx: None,
                 },
                 AtomicWriteSubOperation::ZRem(key, value) => SubOp {
                     key,
                     condition: "true",
-                    write: "redis.call('zrem', $@, $0)",
+                    write: "redis.call('zrem', $@, $0)".to_string(),
                     args: vec![value],
                     failure_tx: None,
                 },
+                AtomicWriteSubOperation::HSet(key, fields) => {
+                    let mut args = Vec::new();
+                    for field in fields {
+                        args.push(field.0.into());
+                        args.push(field.1.into());
+                    }
+                    SubOp {
+                        key,
+                        condition: "true",
+                        write: format!(
+                            "redis.call('hset', $@, {})",
+                            (0..args.len()).map(|i| format!("${}", i)).collect::<Vec<_>>().join(", ")
+                        ),
+                        args,
+                        failure_tx: None,
+                    }
+                }
+                AtomicWriteSubOperation::HDel(key, fields) => {
+                    let args: Vec<_> = fields.into_iter().map(|f| f.into()).collect();
+                    SubOp {
+                        key,
+                        condition: "true",
+                        write: format!(
+                            "redis.call('hdel', $@, {})",
+                            (0..args.len()).map(|i| format!("${}", i)).collect::<Vec<_>>().join(", ")
+                        ),
+                        args,
+                        failure_tx: None,
+                    }
+                }
             })
             .collect();
 
@@ -253,7 +305,7 @@ impl super::Backend for Backend {
                 i + 1,
                 preprocess_atomic_write_expression(op.condition, i + 1, args.len(), op.args.len())
             ));
-            write_expressions.push(preprocess_atomic_write_expression(op.write, i + 1, args.len(), op.args.len()));
+            write_expressions.push(preprocess_atomic_write_expression(&op.write, i + 1, args.len(), op.args.len()));
             keys.push(op.key);
             args.append(&mut op.args);
             failure_txs.push(op.failure_tx);

--- a/src/redisstore.rs
+++ b/src/redisstore.rs
@@ -276,6 +276,13 @@ impl super::Backend for Backend {
                         failure_tx: None,
                     }
                 }
+                AtomicWriteSubOperation::HSetNX(key, field, value, tx) => SubOp {
+                    key,
+                    condition: "redis.call('hexists', $@, $0) == 0",
+                    write: "redis.call('hset', $@, $0, $1)".to_string(),
+                    args: vec![field, value],
+                    failure_tx: Some(tx),
+                },
                 AtomicWriteSubOperation::HDel(key, fields) => {
                     let args: Vec<_> = fields.into_iter().map(|f| f.into()).collect();
                     SubOp {


### PR DESCRIPTION
See https://redis.io/commands/hset and friends.

Like sets, but with extra data associated with each member. Also implemented for Go in https://github.com/ccbrown/keyvaluestore/pull/11.

Rust example:

```rust
pub async fn put_account_user_membership(
    &self,
    membership: &AccountUserMembership,
) -> Result<()> {
    let serialized = Self::serialize(&membership)?;

    let mut tx = AtomicWriteOperation::new();
    tx.h_set(
        store_key!("account_user_memberships:", membership.account_id),
        [(membership.user_id.as_ref(), &serialized)].iter().cloned(),
    );
    tx.h_set(
        store_key!("account_user_memberships:", membership.user_id),
        [(membership.account_id.as_ref(), &serialized)]
            .iter()
            .cloned(),
    );
    self.backend.exec_atomic_write(tx).await?;
    Ok(())
}

pub async fn delete_account_user_membership(
    &self,
    account_id: &Id,
    user_id: &Id,
) -> Result<()> {
    let mut tx = AtomicWriteOperation::new();
    tx.h_del(
        store_key!("account_user_memberships:", account_id),
        [user_id.as_ref()].iter().cloned(),
    );
    tx.h_del(
        store_key!("account_user_memberships:", user_id),
        [account_id.as_ref()].iter().cloned(),
    );
    self.backend.exec_atomic_write(tx).await?;
    Ok(())
}

pub async fn account_user_memberships_by_account_or_user_id(
    &self,
    id: &Id,
) -> Result<Vec<AccountUserMembership>> {
    self.backend
        .h_get_all(store_key!("account_user_memberships:", id))
        .await?
        .into_iter()
        .map(|(_, v)| Ok(Self::deserialize(v.as_ref())?))
        .collect()
}
```