### PR TITLE
add sorted map

### DIFF
--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -178,6 +178,83 @@ macro_rules! test_backend {
 
         #[tokio::test]
         #[serial]
+        async fn test_zh_range_by_score() {
+            let b = $f().await;
+
+            b.zh_add("foo", "a", "-2", -2.0).await.unwrap();
+            b.zh_add("foo", "b", "-1", -1.0).await.unwrap();
+            b.zh_add("foo", "c", "-0.5", -0.5).await.unwrap();
+            b.zh_add("foo", "d", "0", 0.0).await.unwrap();
+            b.zh_add("foo", "e", "0.5", 0.5).await.unwrap();
+            b.zh_add("foo", "f", "0.5b", 0.5).await.unwrap();
+            b.zh_add("foo", "g", "1", 1.0).await.unwrap();
+            b.zh_add("foo", "h", "2", 2.0).await.unwrap();
+
+            // MinMax
+            let members = b.zh_range_by_score("foo", -0.5, 1.0, 0).await.unwrap();
+            assert_eq!(vec!["-0.5", "0", "0.5", "0.5b", "1"], members);
+
+            // Limit
+            let members = b.zh_range_by_score("foo", -0.5, 1.0, 2).await.unwrap();
+            assert_eq!(vec!["-0.5", "0"], members);
+
+            // -Inf
+            let members = b.zh_range_by_score("foo", f64::NEG_INFINITY, 1.0, 0).await.unwrap();
+            assert_eq!(vec!["-2", "-1", "-0.5", "0", "0.5", "0.5b", "1"], members);
+
+            // +Inf
+            let members = b.zh_range_by_score("foo", -0.5, f64::INFINITY, 0).await.unwrap();
+            assert_eq!(vec!["-0.5", "0", "0.5", "0.5b", "1", "2"], members);
+
+            // Rev
+            {
+                // MinMax
+                let members = b.zh_rev_range_by_score("foo", -0.5, 1.0, 0).await.unwrap();
+                assert_eq!(vec!["1", "0.5b", "0.5", "0", "-0.5"], members);
+
+                // Limit
+                let members = b.zh_rev_range_by_score("foo", -0.5, 1.0, 2).await.unwrap();
+                assert_eq!(vec!["1", "0.5b"], members);
+
+                // -Inf
+                let members = b.zh_rev_range_by_score("foo", f64::NEG_INFINITY, 1.0, 0).await.unwrap();
+                assert_eq!(vec!["1", "0.5b", "0.5", "0", "-0.5", "-1", "-2"], members);
+
+                // +Inf
+                let members = b.zh_rev_range_by_score("foo", -0.5, f64::INFINITY, 0).await.unwrap();
+                assert_eq!(vec!["2", "1", "0.5b", "0.5", "0", "-0.5"], members);
+            }
+
+            // ZAddMigration
+            {
+                b.z_add("zaddtest", "a", 0.0).await.unwrap();
+                b.zh_add("zaddtest", "b", "bob", 0.0).await.unwrap();
+                b.z_add("zaddtest", "c", 0.0).await.unwrap();
+                b.zh_add("zaddtest", "d", "dan", 0.0).await.unwrap();
+
+                let members = b.zh_range_by_score("zaddtest", -0.5, 1.0, 0).await.unwrap();
+                assert_eq!(vec!["a", "bob", "c", "dan"], members);
+            }
+
+            // Update
+            {
+                b.zh_add("update-test", "f", "foo", 2.0).await.unwrap();
+
+                let members = b.zh_range_by_score("update-test", 1.5, 2.5, 0).await.unwrap();
+                assert_eq!(vec!["foo"], members);
+
+                b.zh_add("update-test", "f", "foo", 3.0).await.unwrap();
+
+                let members = b.zh_range_by_score("update-test", 1.5, 2.5, 0).await.unwrap();
+                assert_eq!(members.is_empty(), true);
+
+                let members = b.zh_range_by_score("update-test", 2.5, 3.5, 0).await.unwrap();
+                assert_eq!(vec!["foo"], members);
+            }
+        }
+
+        #[tokio::test]
+        #[serial]
         async fn test_z_count() {
             let b = $f().await;
 
@@ -203,6 +280,35 @@ macro_rules! test_backend {
                     .unwrap();
             }
             assert_eq!(b.z_count("big", 0.0, 0.0).await.unwrap(), 1100);
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn test_zh_count() {
+            let b = $f().await;
+
+            b.zh_add("foo", "a", "a", 0.0).await.unwrap();
+            b.zh_add("foo", "b", "b", 1.0).await.unwrap();
+            b.zh_add("foo", "c", "c", 2.0).await.unwrap();
+            b.zh_add("foo", "d", "d", 3.0).await.unwrap();
+            b.zh_add("foo", "e", "e", 4.0).await.unwrap();
+            b.zh_add("foo", "f", "f", 5.0).await.unwrap();
+
+            assert_eq!(b.zh_count("foo", 1.0, 2.0).await.unwrap(), 2);
+            assert_eq!(b.zh_count("foo", 1.0, 1.5).await.unwrap(), 1);
+            assert_eq!(b.zh_count("foo", f64::NEG_INFINITY, 2.0).await.unwrap(), 3);
+            assert_eq!(b.zh_count("foo", f64::NEG_INFINITY, f64::INFINITY).await.unwrap(), 6);
+            assert_eq!(b.zh_count("foo", 2.0, f64::INFINITY).await.unwrap(), 4);
+
+            // DynamoDB has to paginate requests for zh_counts on big sets.
+            let mut big_value = Vec::new();
+            big_value.resize(1000, 'x' as u8);
+            for i in 0..1100 {
+                b.z_add("big", [i.to_string().as_bytes().to_vec(), big_value.clone()].concat(), 0.0)
+                    .await
+                    .unwrap();
+            }
+            assert_eq!(b.zh_count("big", 0.0, 0.0).await.unwrap(), 1100);
         }
 
         #[tokio::test]
@@ -353,6 +459,30 @@ macro_rules! test_backend {
             assert_eq!(b.exec_atomic_write(tx).await.unwrap(), true);
 
             assert_eq!(b.z_count("zset", 0.0, 10.0).await.unwrap(), 1);
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn test_atomic_write_zh_add() {
+            let b = $f().await;
+
+            b.set("zhashcond", "foo").await.unwrap();
+
+            let mut tx = AtomicWriteOperation::new();
+            let c = tx.set_nx("zhashcond", "foo");
+            tx.zh_add("zhash", "f", "foo", 1.0);
+            tx.zh_add("zhash", "b", "bar", 2.0);
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), false);
+            assert_eq!(c.failed(), true);
+
+            assert_eq!(b.zh_count("zhash", 0.0, 10.0).await.unwrap(), 0);
+
+            let mut tx = AtomicWriteOperation::new();
+            tx.zh_add("zhash", "f", "foo", 1.0);
+            tx.zh_add("zhash", "b", "bar", 2.0);
+            assert_eq!(b.exec_atomic_write(tx).await.unwrap(), true);
+
+            assert_eq!(b.zh_count("zhash", 0.0, 10.0).await.unwrap(), 2);
         }
 
         #[tokio::test]

--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -483,6 +483,15 @@ macro_rules! test_backend {
             assert_eq!(b.exec_atomic_write(tx).await.unwrap(), true);
 
             assert_eq!(b.zh_count("zhash", 0.0, 10.0).await.unwrap(), 2);
+
+            // ZHRem
+            {
+                let mut tx = AtomicWriteOperation::new();
+                tx.zh_rem("zhash", "f");
+                assert_eq!(b.exec_atomic_write(tx).await.unwrap(), true);
+
+                assert_eq!(b.zh_count("zhash", 0.0, 10.0).await.unwrap(), 1);
+            }
         }
 
         #[tokio::test]

--- a/src/dynamodbstore.rs
+++ b/src/dynamodbstore.rs
@@ -578,6 +578,14 @@ impl super::Backend for Backend {
                     item.delete = Some(delete);
                     (item, None)
                 }
+                AtomicWriteSubOperation::ZHRem(key, field) => {
+                    let mut delete = Delete::default();
+                    delete.table_name = self.table_name.clone();
+                    delete.key = composite_key(key, field);
+                    let mut item = TransactWriteItem::default();
+                    item.delete = Some(delete);
+                    (item, None)
+                }
                 AtomicWriteSubOperation::HSet(key, fields) => {
                     let (names, values): (HashMap<_, _>, HashMap<_, _>) = fields
                         .into_iter()

--- a/src/dynstore.rs
+++ b/src/dynstore.rs
@@ -138,6 +138,44 @@ impl super::Backend for Backend {
         }
     }
 
+    async fn zh_add<'a, 'b, 'c, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        field: F,
+        value: V,
+        score: f64,
+    ) -> Result<()> {
+        match self {
+            Self::Memory(backend) => backend.zh_add(key, field, value, score).await,
+            Self::Redis(backend) => backend.zh_add(key, field, value, score).await,
+            Self::DynamoDB(backend) => backend.zh_add(key, field, value, score).await,
+        }
+    }
+
+    async fn zh_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize> {
+        match self {
+            Self::Memory(backend) => backend.zh_count(key, min, max).await,
+            Self::Redis(backend) => backend.zh_count(key, min, max).await,
+            Self::DynamoDB(backend) => backend.zh_count(key, min, max).await,
+        }
+    }
+
+    async fn zh_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
+        match self {
+            Self::Memory(backend) => backend.zh_range_by_score(key, min, max, limit).await,
+            Self::Redis(backend) => backend.zh_range_by_score(key, min, max, limit).await,
+            Self::DynamoDB(backend) => backend.zh_range_by_score(key, min, max, limit).await,
+        }
+    }
+
+    async fn zh_rev_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
+        match self {
+            Self::Memory(backend) => backend.zh_rev_range_by_score(key, min, max, limit).await,
+            Self::Redis(backend) => backend.zh_rev_range_by_score(key, min, max, limit).await,
+            Self::DynamoDB(backend) => backend.zh_rev_range_by_score(key, min, max, limit).await,
+        }
+    }
+
     async fn exec_batch(&self, op: BatchOperation<'_>) -> Result<()> {
         match self {
             Self::Memory(backend) => backend.exec_batch(op).await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ pub enum AtomicWriteSubOperation<'a> {
     ZAdd(Arg<'a>, Arg<'a>, f64),
     ZHAdd(Arg<'a>, Arg<'a>, Arg<'a>, f64),
     ZRem(Arg<'a>, Arg<'a>),
+    ZHRem(Arg<'a>, Arg<'a>),
     Delete(Arg<'a>),
     DeleteXX(Arg<'a>, mpsc::SyncSender<bool>),
     SAdd(Arg<'a>, Arg<'a>),
@@ -299,6 +300,10 @@ impl<'a> AtomicWriteOperation<'a> {
 
     pub fn z_rem<'k: 'a, 'v: 'a, K: Into<Arg<'k>> + Send, V: Into<Arg<'v>> + Send>(&mut self, key: K, value: V) {
         self.ops.push(AtomicWriteSubOperation::ZRem(key.into(), value.into()));
+    }
+
+    pub fn zh_rem<'k: 'a, 'f: 'a, K: Into<Arg<'k>> + Send, F: Into<Arg<'f>> + Send>(&mut self, key: K, field: F) {
+        self.ops.push(AtomicWriteSubOperation::ZHRem(key.into(), field.into()));
     }
 
     pub fn delete<'k: 'a, K: Into<Arg<'k>> + Send>(&mut self, key: K) {

--- a/src/memorystore.rs
+++ b/src/memorystore.rs
@@ -105,26 +105,33 @@ impl Backend {
         Ok(())
     }
 
-    fn z_add<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(m: &mut HashMap<Vec<u8>, MapEntry>, key: K, value: V, score: f64) -> Result<()> {
+    fn zh_add<'a, 'b, 'c, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send>(
+        m: &mut HashMap<Vec<u8>, MapEntry>,
+        key: K,
+        field: F,
+        value: V,
+        score: f64,
+    ) -> Result<()> {
         let key = key.into();
+        let field = field.into();
         let value = value.into();
         match m.get_mut(key.as_bytes()) {
             Some(MapEntry::SortedSet(s)) => {
-                if let Some(&previous_score) = s.scores_by_member.get(value.as_bytes()) {
-                    s.scores_by_member.remove(value.as_bytes());
-                    s.m.remove(&[&float_sort_key(previous_score), value.as_bytes()].concat());
+                if let Some(&previous_score) = s.scores_by_member.get(field.as_bytes()) {
+                    s.scores_by_member.remove(field.as_bytes());
+                    s.m.remove(&[&float_sort_key(previous_score), field.as_bytes()].concat());
                 }
 
-                s.scores_by_member.insert(value.to_vec(), score);
-                s.m.insert([&float_sort_key(score), value.as_bytes()].concat(), value.into_vec());
+                s.scores_by_member.insert(field.to_vec(), score);
+                s.m.insert([&float_sort_key(score), field.as_bytes()].concat(), value.into_vec());
             }
             None => {
                 let mut s = SortedSet {
                     scores_by_member: HashMap::new(),
                     m: BTreeMap::new(),
                 };
-                s.scores_by_member.insert(value.to_vec(), score);
-                s.m.insert([&float_sort_key(score), value.as_bytes()].concat(), value.into_vec());
+                s.scores_by_member.insert(field.to_vec(), score);
+                s.m.insert([&float_sort_key(score), field.as_bytes()].concat(), value.into_vec());
                 m.insert(key.into_vec(), MapEntry::SortedSet(s));
             }
             _ => return Err(Box::new(SimpleError::new("attempt to add sorted set member to existing non-sorted-set value"))),
@@ -274,11 +281,27 @@ impl super::Backend for Backend {
 
     async fn z_add<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V, score: f64) -> Result<()> {
         let mut m = self.m.lock().unwrap();
-        Self::z_add(&mut m, key, value, score)
+        let v = value.into();
+        Self::zh_add(&mut m, key, &v, &v, score)
+    }
+
+    async fn zh_add<'a, 'b, 'c, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        field: F,
+        value: V,
+        score: f64,
+    ) -> Result<()> {
+        let mut m = self.m.lock().unwrap();
+        Self::zh_add(&mut m, key, field, value, score)
     }
 
     async fn z_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize> {
         Ok(self.z_range_by_score(key, min, max, 0).await?.len())
+    }
+
+    async fn zh_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize> {
+        self.z_count(key, min, max).await
     }
 
     async fn z_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
@@ -301,6 +324,10 @@ impl super::Backend for Backend {
             .take(if limit > 0 { limit } else { s.m.len() })
             .map(|(_, v)| v.clone().into())
             .collect())
+    }
+
+    async fn zh_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
+        self.z_range_by_score(key, min, max, limit).await
     }
 
     async fn z_rev_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
@@ -326,6 +353,10 @@ impl super::Backend for Backend {
             .collect())
     }
 
+    async fn zh_rev_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
+        self.z_rev_range_by_score(key, min, max, limit).await
+    }
+
     async fn exec_atomic_write(&self, op: AtomicWriteOperation<'_>) -> Result<bool> {
         if op.ops.len() > MAX_ATOMIC_WRITE_SUB_OPERATIONS {
             return Err(Box::new(SimpleError::new("max sub-operation count exceeded")));
@@ -344,6 +375,7 @@ impl super::Backend for Backend {
                     }
                 }
                 AtomicWriteSubOperation::ZAdd(..) => None,
+                AtomicWriteSubOperation::ZHAdd(..) => None,
                 AtomicWriteSubOperation::ZRem(..) => None,
                 AtomicWriteSubOperation::Delete(..) => None,
                 AtomicWriteSubOperation::DeleteXX(key, tx) => {
@@ -395,7 +427,11 @@ impl super::Backend for Backend {
                     Self::s_rem(&mut m, key, value)?;
                 }
                 AtomicWriteSubOperation::ZAdd(key, value, score) => {
-                    Self::z_add(&mut m, key, value, score)?;
+                    let v: Arg = value.into();
+                    Self::zh_add(&mut m, key, &v, &v, score)?;
+                }
+                AtomicWriteSubOperation::ZHAdd(key, field, value, score) => {
+                    Self::zh_add(&mut m, key, field, value, score)?;
                 }
                 AtomicWriteSubOperation::ZRem(key, value) => {
                     Self::z_rem(&mut m, key, value)?;

--- a/src/redisstore.rs
+++ b/src/redisstore.rs
@@ -337,6 +337,13 @@ impl super::Backend for Backend {
                     args: vec![value],
                     failure_tx: None,
                 },
+                AtomicWriteSubOperation::ZHRem(key, field) => SubOp {
+                    keys: vec![[ZH_HASH_KEY_PREFIX.as_bytes(), key.as_bytes()].concat().into(), key],
+                    condition: "true",
+                    write: "redis.call('zrem', @1, $0)\nredis.call('hdel', @0, $0)".to_string(),
+                    args: vec![field],
+                    failure_tx: None,
+                },
                 AtomicWriteSubOperation::HSet(key, fields) => {
                     let mut args = Vec::new();
                     for field in fields {


### PR DESCRIPTION
This adds methods which implement a "sorted hash" type. It is equivalent to a sorted set + hash in Redis. In Redis it's actually implemented using a sorted set + hash, but for DynamoDB it's implemented in a much more efficient way, which should result in faster queries that require fewer RCUs.