### PR TITLE
add z_range_by_lex

### DIFF
--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -194,17 +194,14 @@ macro_rules! test_backend {
                 .unwrap();
             assert_eq!(vec!["a", "b", "c", "d"], members);
 
-            /*
             // MinGreaterThanMax
             let members = b.z_range_by_lex("foo", Bound::Excluded("d"), Bound::Excluded("a"), 0).await.unwrap();
             assert_eq!(members.is_empty(), true);
-            */
 
             // MinMaxExclusive
             let members = b.z_range_by_lex("foo", Bound::Excluded("a"), Bound::Excluded("d"), 0).await.unwrap();
             assert_eq!(vec!["b", "c"], members);
 
-            /*
             // MinMaxInclusive
             let members = b.z_range_by_lex("foo", Bound::Included("a"), Bound::Included("d"), 0).await.unwrap();
             assert_eq!(vec!["a", "b", "c", "d"], members);
@@ -246,7 +243,6 @@ macro_rules! test_backend {
                 let members = b.z_rev_range_by_lex("foo", Bound::Included("z"), Bound::Included("z"), 1).await.unwrap();
                 assert_eq!(members.is_empty(), true);
             }
-            */
         }
 
         #[tokio::test]

--- a/src/dynstore.rs
+++ b/src/dynstore.rs
@@ -1,5 +1,5 @@
 use super::{dynamodbstore, memorystore, readcache, redisstore, Arg, AtomicWriteOperation, BatchOperation, Result, Value};
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Bound};
 
 #[derive(Clone)]
 pub enum Backend {
@@ -203,6 +203,36 @@ impl super::Backend for Backend {
             Self::Redis(backend) => backend.zh_rev_range_by_score(key, min, max, limit).await,
             Self::DynamoDB(backend) => backend.zh_rev_range_by_score(key, min, max, limit).await,
             Self::ReadCache(backend) => backend.zh_rev_range_by_score(key, min, max, limit).await,
+        }
+    }
+
+    async fn z_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
+        match self {
+            Self::Memory(backend) => backend.z_range_by_lex(key, min, max, limit).await,
+            Self::Redis(backend) => backend.z_range_by_lex(key, min, max, limit).await,
+            Self::DynamoDB(backend) => backend.z_range_by_lex(key, min, max, limit).await,
+            Self::ReadCache(backend) => backend.z_range_by_lex(key, min, max, limit).await,
+        }
+    }
+
+    async fn z_rev_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
+        match self {
+            Self::Memory(backend) => backend.z_rev_range_by_lex(key, min, max, limit).await,
+            Self::Redis(backend) => backend.z_rev_range_by_lex(key, min, max, limit).await,
+            Self::DynamoDB(backend) => backend.z_rev_range_by_lex(key, min, max, limit).await,
+            Self::ReadCache(backend) => backend.z_rev_range_by_lex(key, min, max, limit).await,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate async_trait;
 extern crate serial_test;
 extern crate simple_error;
 
-use std::{collections::HashMap, convert::From, fmt, sync::mpsc};
+use std::{collections::HashMap, convert::From, fmt, ops::Bound, sync::mpsc};
 
 pub mod backendtest;
 pub mod dynamodbstore;
@@ -188,6 +188,20 @@ pub trait Backend {
     async fn z_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize>;
     async fn z_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>>;
     async fn z_rev_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>>;
+    async fn z_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>>;
+    async fn z_rev_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>>;
 
     async fn zh_add<'a, 'b, 'c, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send>(
         &self,

--- a/src/memorystore.rs
+++ b/src/memorystore.rs
@@ -1,7 +1,7 @@
 use super::{Arg, AtomicWriteOperation, AtomicWriteSubOperation, Result, Value, MAX_ATOMIC_WRITE_SUB_OPERATIONS};
 use simple_error::SimpleError;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::ops::Bound::{Excluded, Included, Unbounded};
+use std::ops::Bound::{self, Excluded, Included, Unbounded};
 use std::sync::{mpsc, Arc, Mutex};
 
 struct SortedSet {
@@ -187,6 +187,14 @@ fn float_sort_key_after(f: f64) -> Option<[u8; 8]> {
     }
 }
 
+fn map_bound<T, U, F: FnOnce(T) -> U>(b: Bound<T>, f: F) -> Bound<U> {
+    match b {
+        Bound::Included(v) => Bound::Included(f(v)),
+        Bound::Excluded(v) => Bound::Excluded(f(v)),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
 #[async_trait]
 impl super::Backend for Backend {
     async fn get<'a, K: Into<Arg<'a>> + Send>(&self, key: K) -> Result<Option<Value>> {
@@ -363,6 +371,57 @@ impl super::Backend for Backend {
 
     async fn zh_rev_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
         self.z_rev_range_by_score(key, min, max, limit).await
+    }
+
+    async fn z_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
+        let m = self.m.lock().unwrap();
+        let key = key.into();
+
+        let s = match m.get(key.as_bytes()) {
+            Some(MapEntry::SortedSet(s)) => s,
+            _ => return Ok(vec![]),
+        };
+
+        let min = map_bound(min, |v| (&[&float_sort_key(0.0), v.into().as_bytes()]).concat().to_vec());
+        let max = map_bound(max, |v| (&[&float_sort_key(0.0), v.into().as_bytes()]).concat().to_vec());
+
+        Ok(s.m
+            .range((min, max))
+            .take(if limit > 0 { limit } else { s.m.len() })
+            .map(|(_, v)| v.clone().into())
+            .collect())
+    }
+
+    async fn z_rev_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
+        let m = self.m.lock().unwrap();
+        let key = key.into();
+
+        let s = match m.get(key.as_bytes()) {
+            Some(MapEntry::SortedSet(s)) => s,
+            _ => return Ok(vec![]),
+        };
+
+        let min = map_bound(min, |v| (&[&float_sort_key(0.0), v.into().as_bytes()]).concat().to_vec());
+        let max = map_bound(max, |v| (&[&float_sort_key(0.0), v.into().as_bytes()]).concat().to_vec());
+
+        Ok(s.m
+            .range((min, max))
+            .rev()
+            .take(if limit > 0 { limit } else { s.m.len() })
+            .map(|(_, v)| v.clone().into())
+            .collect())
     }
 
     async fn exec_atomic_write(&self, op: AtomicWriteOperation<'_>) -> Result<bool> {

--- a/src/readcache.rs
+++ b/src/readcache.rs
@@ -1,6 +1,7 @@
 use super::{Arg, AtomicWriteOperation, AtomicWriteSubOperation, BatchOperation, BatchSubOperation, Result, Value};
 use std::{
     collections::HashMap,
+    ops::Bound,
     sync::{mpsc, Arc, Mutex},
 };
 
@@ -240,6 +241,26 @@ impl<B: super::Backend + Send + Sync> super::Backend for Backend<B> {
 
     async fn zh_rev_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
         self.inner.zh_rev_range_by_score(key, min, max, limit).await
+    }
+
+    async fn z_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
+        self.inner.z_range_by_lex(key, min, max, limit).await
+    }
+
+    async fn z_rev_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
+        &self,
+        key: K,
+        min: Bound<M>,
+        max: Bound<N>,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
+        self.inner.z_rev_range_by_lex(key, min, max, limit).await
     }
 
     async fn exec_batch(&self, op: BatchOperation<'_>) -> Result<()> {


### PR DESCRIPTION
Adds `z_range_by_lex` and `z_rev_range_by_lex`, which are identical in functionality to the method in https://github.com/ccbrown/keyvaluestore.