### PR TITLE
add atomic set eq op

### DIFF
--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -464,6 +464,34 @@ macro_rules! test_backend {
 
         #[tokio::test]
         #[serial]
+        async fn test_atomic_write_set_eq() {
+            let b = ($f)().await;
+
+            let mut tx = AtomicWriteOperation::new();
+            let c = tx.set_eq("foo", "baz", "bar");
+            assert!(!b.exec_atomic_write(tx).await.unwrap());
+            assert!(c.failed());
+
+            b.set("foo", "bar").await.unwrap();
+
+            let mut tx = AtomicWriteOperation::new();
+            let c = tx.set_eq("foo", "baz", "asdf");
+            assert!(!b.exec_atomic_write(tx).await.unwrap());
+            assert!(c.failed());
+
+            let mut tx = AtomicWriteOperation::new();
+            let c = tx.set_eq("foo", "baz", "bar");
+            assert!(b.exec_atomic_write(tx).await.unwrap());
+            assert!(!c.failed());
+
+            let mut tx = AtomicWriteOperation::new();
+            let c = tx.set_eq("foo", "baz", "baz");
+            assert!(b.exec_atomic_write(tx).await.unwrap());
+            assert!(!c.failed());
+        }
+
+        #[tokio::test]
+        #[serial]
         async fn test_atomic_write_set_nx() {
             let b = ($f)().await;
 

--- a/src/dynamodbstore.rs
+++ b/src/dynamodbstore.rs
@@ -617,6 +617,16 @@ impl super::Backend for Backend {
                     item.put = Some(put);
                     (item, None)
                 }
+                AtomicWriteSubOperation::SetEQ(key, value, old_value, tx) => {
+                    let mut put = Put::default();
+                    put.table_name = self.table_name.clone();
+                    put.item = new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
+                    put.condition_expression = Some("v = :v".to_string());
+                    put.expression_attribute_values = Some(vec![(":v".to_string(), attribute_value(old_value))].into_iter().collect());
+                    let mut item = TransactWriteItem::default();
+                    item.put = Some(put);
+                    (item, Some(tx))
+                }
                 AtomicWriteSubOperation::SetNX(key, value, tx) => {
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();

--- a/src/readcache.rs
+++ b/src/readcache.rs
@@ -322,6 +322,7 @@ impl<B: super::Backend + Send + Sync> super::Backend for Backend<B> {
             keys.push(
                 match subop {
                     AtomicWriteSubOperation::Set(key, _) => key,
+                    AtomicWriteSubOperation::SetEQ(key, _, _, _) => key,
                     AtomicWriteSubOperation::SetNX(key, _, _) => key,
                     AtomicWriteSubOperation::Delete(key) => key,
                     AtomicWriteSubOperation::DeleteXX(key, _) => key,

--- a/src/redisstore.rs
+++ b/src/redisstore.rs
@@ -328,6 +328,13 @@ impl super::Backend for Backend {
                     args: vec![value],
                     failure_tx: None,
                 },
+                AtomicWriteSubOperation::SetEQ(key, value, old_value, tx) => SubOp {
+                    keys: vec![key],
+                    condition: "redis.call('get', @0) == $1",
+                    write: "redis.call('set', @0, $0)".to_string(),
+                    args: vec![value, old_value],
+                    failure_tx: Some(tx),
+                },
                 AtomicWriteSubOperation::SetNX(key, value, tx) => SubOp {
                     keys: vec![key],
                     condition: "redis.call('exists', @0) == 0",


### PR DESCRIPTION
Adds `set_eq` for atomic operations. We already had this for non-atomic operations, and the Go library has also already had it. This just adds it to atomic operations here too.