### PR TITLE
add zh rem operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "keyvaluestore"
 version = "0.1.0"
 authors = ["Christopher Brown <ccbrown112@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 async-trait = "0.1.32"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   dev:
-    image: rust:1.53
+    image: rust:1.62
     environment:
       DYNAMODB_ENDPOINT: http://dynamodb.local:8000
       REDIS_ADDRESS: redis.local:6379

--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -359,6 +359,23 @@ macro_rules! test_backend {
 
         #[tokio::test]
         #[serial]
+        async fn test_zh_rem() {
+            let b = ($f)().await;
+
+            b.zh_add("foo", "f", "foo", 1.0).await.unwrap();
+            b.zh_add("foo", "b", "bar", 2.0).await.unwrap();
+
+            let members = b.zh_range_by_score("foo", 0.0, 10.0, 0).await.unwrap();
+            assert_eq!(vec!["foo", "bar"], members);
+
+            b.zh_rem("foo", "b").await.unwrap();
+
+            let members = b.zh_range_by_score("foo", 0.0, 10.0, 0).await.unwrap();
+            assert_eq!(vec!["foo"], members);
+        }
+
+        #[tokio::test]
+        #[serial]
         async fn test_z_count() {
             let b = ($f)().await;
 

--- a/src/dynamodbstore.rs
+++ b/src/dynamodbstore.rs
@@ -454,12 +454,16 @@ impl super::Backend for Backend {
         Ok(())
     }
 
-    async fn z_rem<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+    async fn zh_rem<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<()> {
         let mut delete = rusoto_dynamodb::DeleteItemInput::default();
         delete.table_name = self.table_name.clone();
-        delete.key = composite_key(key, value);
+        delete.key = composite_key(key, field);
         self.client.delete_item(delete).await?;
         Ok(())
+    }
+
+    async fn z_rem<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+        self.zh_rem(key, value).await
     }
 
     async fn z_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize> {

--- a/src/dynstore.rs
+++ b/src/dynstore.rs
@@ -215,6 +215,15 @@ impl super::Backend for Backend {
         }
     }
 
+    async fn zh_rem<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<()> {
+        match self {
+            Self::Memory(backend) => backend.zh_rem(key, field).await,
+            Self::Redis(backend) => backend.zh_rem(key, field).await,
+            Self::DynamoDB(backend) => backend.zh_rem(key, field).await,
+            Self::ReadCache(backend) => backend.zh_rem(key, field).await,
+        }
+    }
+
     async fn z_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
         &self,
         key: K,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,7 @@ pub trait Backend {
         value: V,
         score: f64,
     ) -> Result<()>;
+    async fn zh_rem<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<()>;
     async fn zh_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize>;
     async fn zh_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>>;
     async fn zh_rev_range_by_score<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>>;

--- a/src/memorystore.rs
+++ b/src/memorystore.rs
@@ -336,9 +336,13 @@ impl super::Backend for Backend {
         Self::zh_add(&mut m, key, field, value, score)
     }
 
-    async fn z_rem<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+    async fn zh_rem<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<()> {
         let mut m = self.m.lock().unwrap();
-        Self::zh_rem(&mut m, key, value)
+        Self::zh_rem(&mut m, key, field)
+    }
+
+    async fn z_rem<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+        self.zh_rem(key, value).await
     }
 
     async fn z_count<'a, K: Into<Arg<'a>> + Send>(&self, key: K, min: f64, max: f64) -> Result<usize> {

--- a/src/readcache.rs
+++ b/src/readcache.rs
@@ -250,6 +250,13 @@ impl<B: super::Backend + Send + Sync> super::Backend for Backend<B> {
         self.inner.zh_rev_range_by_score(key, min, max, limit).await
     }
 
+    async fn zh_rem<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<()> {
+        let key = key.into();
+        let r = self.inner.zh_rem(&key, field).await;
+        self.invalidate(&key);
+        r
+    }
+
     async fn z_range_by_lex<'a, 'b, 'c, K: Into<Arg<'a>> + Send, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
         &self,
         key: K,

--- a/src/redisstore.rs
+++ b/src/redisstore.rs
@@ -186,6 +186,20 @@ impl super::Backend for Backend {
         Ok(())
     }
 
+    async fn zh_rem<'a, 'b, K: Into<Arg<'a>> + Send, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<()> {
+        let key = key.into();
+        let field = field.into();
+        let mut conn = self.get_connection().await?;
+        redis::pipe()
+            .atomic()
+            .zrem(&key, &field)
+            .hdel([ZH_HASH_KEY_PREFIX.as_bytes(), key.as_bytes()].concat(), &field)
+            .ignore()
+            .query_async::<_, Option<()>>(&mut conn)
+            .await?;
+        Ok(())
+    }
+
     async fn z_rem<'a, 'b, K: Into<Arg<'a>> + Send, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
         Ok(self.get_connection().await?.zrem(key.into(), value.into()).await?)
     }


### PR DESCRIPTION
This adds the "ZH rem" operation, which is an especially easy one to add here since for DynamoDB and the memory store, it's identical to "Z rem".

This operation removes a field from a sorted hash.

Implementations and tests copied directly from https://github.com/ccbrown/keyvaluestore.