### PR TITLE
[AVS-585] aws_sdk_dynamodb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ rusoto_dynamodb = { git = "https://github.com/sportsball-ai/rusoto", rev = "98e5
 bytes = "1.0"
 rand = "0.7.3"
 base64 = "0.12.2"
+aws-sdk-dynamodb = { version = "0.21.0", optional = true }
 
 [features]
+aws-sdk = ["dep:aws-sdk-dynamodb"]
 redis = ["dep:redis"]
 rusoto = ["dep:rusoto_core", "dep:rusoto_credential", "dep:rusoto_dynamodb"]
 

--- a/src/dynstore.rs
+++ b/src/dynstore.rs
@@ -4,6 +4,8 @@ use std::{collections::HashMap, ops::Bound};
 #[derive(Clone)]
 #[non_exhaustive]
 pub enum Backend {
+    #[cfg(feature = "aws-sdk")]
+    AwsSdkDynamoDB(crate::aws_sdk_dynamodbstore::Backend),
     Memory(memorystore::Backend),
     #[cfg(feature = "redis")]
     Redis(crate::redisstore::Backend),
@@ -20,6 +22,8 @@ pub enum Backend {
 macro_rules! dispatch {
     ($self:ident, $backend:ident, { $expansion:expr }) => {
         match $self {
+            #[cfg(feature = "aws-sdk")]
+            Self::AwsSdkDynamoDB($backend) => $expansion,
             Self::Memory($backend) => $expansion,
             #[cfg(feature = "redis")]
             Self::Redis($backend) => $expansion,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ use std::{collections::HashMap, convert::From, fmt, ops::Bound, sync::mpsc};
 
 pub mod backendtest;
 
+#[cfg(feature = "aws-sdk")]
+pub mod aws_sdk_dynamodbstore;
 pub mod dynstore;
 pub mod memorystore;
 pub mod readcache;


### PR DESCRIPTION
Builds on sportsball-ai/keyvaluestore-rs#12.

This started with `git cp src/{rusoto,aws_sdk}_dynamodbstore.rs`, so the easiest review is likely by diffing those files. I opted not to share any code between the two. My hope is eventually we'll delete the Rusoto version and be back to one self-contained module.

Only one (intentional) functional change: I dropped the fallback from pay-per-request to provisioned throughput. I couldn't figure out how that error condition would be expressed with the new aws_sdk error returns because the error didn't actually happen for me with DynamoDB local. I figure they've since fixed this, so the workaround is no longer necessary. I matched this change in the rusoto version for consistency.