### PR TITLE
improve rusoto `exec_atomic_write` errors

### DIFF
--- a/src/aws_sdk_dynamodbstore.rs
+++ b/src/aws_sdk_dynamodbstore.rs
@@ -30,14 +30,14 @@ fn new_item<'h, 's, S: Into<Arg<'s>> + Send, A: IntoIterator<Item = (&'static st
     attrs: A,
 ) -> HashMap<String, AttributeValue> {
     let mut ret: HashMap<_, _> = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
-    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
+    ret.insert("hk".to_string(), attribute_value(hash.unredacted.as_bytes()));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }
 
 fn composite_key<'h, 's, S: Into<Arg<'s>> + Send>(hash: &ExplicitKey<'h>, sort: S) -> HashMap<String, AttributeValue> {
     let mut ret = HashMap::new();
-    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
+    ret.insert("hk".to_string(), attribute_value(hash.unredacted.as_bytes()));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }

--- a/src/aws_sdk_dynamodbstore.rs
+++ b/src/aws_sdk_dynamodbstore.rs
@@ -25,19 +25,19 @@ pub struct Backend {
 const NO_SORT_KEY: &str = "_";
 
 fn new_item<'h, 's, S: Into<Arg<'s>> + Send, A: IntoIterator<Item = (&'static str, AttributeValue)>>(
-    hash: ExplicitKey<'h>,
+    hash: &ExplicitKey<'h>,
     sort: S,
     attrs: A,
 ) -> HashMap<String, AttributeValue> {
     let mut ret: HashMap<_, _> = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
-    ret.insert("hk".to_string(), attribute_value(hash.unredacted));
+    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }
 
-fn composite_key<'h, 's, S: Into<Arg<'s>> + Send>(hash: ExplicitKey<'h>, sort: S) -> HashMap<String, AttributeValue> {
+fn composite_key<'h, 's, S: Into<Arg<'s>> + Send>(hash: &ExplicitKey<'h>, sort: S) -> HashMap<String, AttributeValue> {
     let mut ret = HashMap::new();
-    ret.insert("hk".to_string(), attribute_value(hash.unredacted));
+    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }
@@ -262,7 +262,7 @@ impl super::Backend for Backend {
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
             .await?;
@@ -276,7 +276,7 @@ impl super::Backend for Backend {
         self.client
             .put_item()
             .table_name(self.table_name.clone())
-            .set_item(Some(new_item(key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
+            .set_item(Some(new_item(&key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
             .send()
             .await?;
         Ok(())
@@ -287,7 +287,7 @@ impl super::Backend for Backend {
             .client
             .put_item()
             .table_name(self.table_name.clone())
-            .set_item(Some(new_item(key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
+            .set_item(Some(new_item(&key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
             .condition_expression("v = :v")
             .expression_attribute_values(":v", attribute_value(old_value))
             .send()
@@ -308,7 +308,7 @@ impl super::Backend for Backend {
             .client
             .put_item()
             .table_name(self.table_name.clone())
-            .set_item(Some(new_item(key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
+            .set_item(Some(new_item(&key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
             .condition_expression("attribute_not_exists(v)")
             .send()
             .await
@@ -328,7 +328,7 @@ impl super::Backend for Backend {
             .client
             .delete_item()
             .table_name(self.table_name.clone())
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .return_values(ReturnValue::AllOld)
             .send()
             .await?;
@@ -340,7 +340,7 @@ impl super::Backend for Backend {
         let v = AttributeValue::Bs(vec![Blob::new(value.into_vec())]);
         self.client
             .update_item()
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression("ADD v :v")
             .expression_attribute_values(":v", v)
@@ -354,7 +354,7 @@ impl super::Backend for Backend {
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
             .await?;
@@ -372,7 +372,7 @@ impl super::Backend for Backend {
         let output = self
             .client
             .update_item()
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression("ADD v :n")
             .expression_attribute_values(":n", AttributeValue::N(n.to_string()))
@@ -405,7 +405,7 @@ impl super::Backend for Backend {
             .unzip();
         self.client
             .update_item()
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression(format!(
                 "SET {}",
@@ -426,7 +426,7 @@ impl super::Backend for Backend {
             .collect();
         self.client
             .update_item()
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression(format!(
                 "REMOVE {}",
@@ -443,7 +443,7 @@ impl super::Backend for Backend {
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
             .await?;
@@ -461,7 +461,7 @@ impl super::Backend for Backend {
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
             .await?;
@@ -492,7 +492,7 @@ impl super::Backend for Backend {
             .put_item()
             .table_name(self.table_name.clone())
             .set_item(Some(new_item(
-                key.into(),
+                &key.into(),
                 &field,
                 vec![
                     ("v", attribute_value(&value)),
@@ -508,7 +508,7 @@ impl super::Backend for Backend {
         self.client
             .delete_item()
             .table_name(self.table_name.clone())
-            .set_key(Some(composite_key(key.into(), field)))
+            .set_key(Some(composite_key(&key.into(), field)))
             .send()
             .await?;
         Ok(())
@@ -603,7 +603,7 @@ impl super::Backend for Backend {
             .ops
             .iter()
             .map(|op| match op {
-                BatchSubOperation::Get(key, _) => composite_key(key.clone(), NO_SORT_KEY),
+                BatchSubOperation::Get(key, _) => composite_key(&key, NO_SORT_KEY),
             })
             .collect();
 
@@ -666,7 +666,12 @@ impl super::Backend for Backend {
         rand::thread_rng().fill_bytes(&mut token);
         let token = base64::encode_config(token, base64::URL_SAFE_NO_PAD);
 
-        let (transact_items, failure_txs): (Vec<_>, Vec<_>) = op
+        struct SubOpState {
+            key: ExplicitKey<'static>,
+            failure_tx: Option<mpsc::SyncSender<bool>>,
+        }
+
+        let (transact_items, states): (Vec<_>, Vec<_>) = op
             .ops
             .into_iter()
             .map(|op| match op {
@@ -675,59 +680,89 @@ impl super::Backend for Backend {
                         .put(
                             Put::builder()
                                 .table_name(self.table_name.clone())
-                                .set_item(Some(new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
+                                .set_item(Some(new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SetEQ(key, value, old_value, tx) => {
                     let item = TransactWriteItem::builder()
                         .put(
                             Put::builder()
                                 .table_name(self.table_name.clone())
-                                .set_item(Some(new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
+                                .set_item(Some(new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
                                 .condition_expression("v = :v")
                                 .expression_attribute_values(":v", attribute_value(old_value))
                                 .build(),
                         )
                         .build();
-                    (item, Some(tx))
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SetNX(key, value, tx) => {
                     let item = TransactWriteItem::builder()
                         .put(
                             Put::builder()
                                 .table_name(self.table_name.clone())
-                                .set_item(Some(new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
+                                .set_item(Some(new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
                                 .condition_expression("attribute_not_exists(v)")
                                 .build(),
                         )
                         .build();
-                    (item, Some(tx))
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::Delete(key) => {
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, NO_SORT_KEY)))
+                                .set_key(Some(composite_key(&key, NO_SORT_KEY)))
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::DeleteXX(key, tx) => {
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, NO_SORT_KEY)))
+                                .set_key(Some(composite_key(&key, NO_SORT_KEY)))
                                 .condition_expression("attribute_exists(v)")
                                 .build(),
                         )
                         .build();
-                    (item, Some(tx))
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SAdd(key, value) => {
                     let v = AttributeValue::Bs(vec![Blob::new(value.into_vec())]);
@@ -735,13 +770,19 @@ impl super::Backend for Backend {
                         .update(
                             Update::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, NO_SORT_KEY)))
+                                .set_key(Some(composite_key(&key, NO_SORT_KEY)))
                                 .update_expression("ADD v :v")
                                 .expression_attribute_values(":v", v)
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SRem(key, value) => {
                     let v = AttributeValue::Bs(vec![Blob::new(value.into_vec())]);
@@ -749,13 +790,19 @@ impl super::Backend for Backend {
                         .update(
                             Update::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, NO_SORT_KEY)))
+                                .set_key(Some(composite_key(&key, NO_SORT_KEY)))
                                 .update_expression("DELETE v :v")
                                 .expression_attribute_values(":v", v)
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZAdd(key, value, score) => {
                     let item = TransactWriteItem::builder()
@@ -763,7 +810,7 @@ impl super::Backend for Backend {
                             Put::builder()
                                 .table_name(self.table_name.clone())
                                 .set_item(Some(new_item(
-                                    key,
+                                    &key,
                                     &value,
                                     vec![
                                         ("v", attribute_value(&value)),
@@ -773,7 +820,13 @@ impl super::Backend for Backend {
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZHAdd(key, field, value, score) => {
                     let item = TransactWriteItem::builder()
@@ -781,7 +834,7 @@ impl super::Backend for Backend {
                             Put::builder()
                                 .table_name(self.table_name.clone())
                                 .set_item(Some(new_item(
-                                    key,
+                                    &key,
                                     &field,
                                     vec![
                                         ("v", attribute_value(&value)),
@@ -791,29 +844,47 @@ impl super::Backend for Backend {
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZRem(key, value) => {
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, value)))
+                                .set_key(Some(composite_key(&key, value)))
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZHRem(key, field) => {
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, field)))
+                                .set_key(Some(composite_key(&key, field)))
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::HSet(key, fields) => {
                     let (names, values): (HashMap<_, _>, HashMap<_, _>) = fields
@@ -828,7 +899,7 @@ impl super::Backend for Backend {
                         .update(
                             Update::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, NO_SORT_KEY)))
+                                .set_key(Some(composite_key(&key, NO_SORT_KEY)))
                                 .update_expression(format!(
                                     "SET {}",
                                     (0..names.len()).map(|i| format!("#n{} = :n{}", i, i)).collect::<Vec<_>>().join(", ")
@@ -838,7 +909,13 @@ impl super::Backend for Backend {
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::HSetNX(key, field, value, tx) => {
                     let v = AttributeValue::B(Blob::new(value.into_vec()));
@@ -846,7 +923,7 @@ impl super::Backend for Backend {
                         .update(
                             Update::builder()
                                 .table_name(self.table_name.clone())
-                                .set_key(Some(composite_key(key, NO_SORT_KEY)))
+                                .set_key(Some(composite_key(&key, NO_SORT_KEY)))
                                 .condition_expression("attribute_not_exists(#f)")
                                 .update_expression("SET #f = :v")
                                 .expression_attribute_values(":v", v)
@@ -854,7 +931,13 @@ impl super::Backend for Backend {
                                 .build(),
                         )
                         .build();
-                    (item, Some(tx))
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::HDel(key, fields) => {
                     let names: HashMap<_, _> = fields
@@ -865,7 +948,7 @@ impl super::Backend for Backend {
                     let item = TransactWriteItem::builder()
                         .update(
                             Update::builder()
-                                .set_key(Some(composite_key(key, NO_SORT_KEY)))
+                                .set_key(Some(composite_key(&key, NO_SORT_KEY)))
                                 .table_name(self.table_name.clone())
                                 .update_expression(format!(
                                     "REMOVE {}",
@@ -875,7 +958,13 @@ impl super::Backend for Backend {
                                 .build(),
                         )
                         .build();
-                    (item, None)
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                        },
+                    )
                 }
             })
             .unzip();
@@ -892,24 +981,28 @@ impl super::Backend for Backend {
                 kind: TransactWriteItemsErrorKind::TransactionCanceledException(cancel),
                 ..
             }) => {
-                let mut did_fail_conditional = false;
+                let mut err = None;
                 for (i, reason) in cancel.cancellation_reasons().unwrap_or(&[]).iter().enumerate() {
-                    if matches!(reason.code(), Some("ConditionalCheckFailed")) {
-                        did_fail_conditional = true;
-                        if let Some(Some(tx)) = failure_txs.get(i) {
-                            match tx.try_send(true) {
-                                Ok(_) => {}
-                                Err(mpsc::TrySendError::Disconnected(_)) => {}
-                                Err(e) => return Err(e.into()),
+                    let Some(code) = reason.code.as_deref() else {
+                        continue;
+                    };
+                    let state = &states[i];
+                    match code {
+                        "ConditionalCheckFailed" => {
+                            if let Some(ref tx) = state.failure_tx {
+                                let _ = tx.try_send(true);
                             }
+                        }
+                        "AtomicWriteConflict" => {
+                            err.get_or_insert_with(|| Error::AtomicWriteConflict(state.key.clone()));
+                        }
+                        "None" => {}
+                        _ => {
+                            err.get_or_insert_with(|| Error::Other(format!("{:?} failed with {}", &state.key, code).into()));
                         }
                     }
                 }
-                if did_fail_conditional {
-                    Ok(false)
-                } else {
-                    Err(Error::AtomicWriteConflict)
-                }
+                return err.map(Err).unwrap_or(Ok(false));
             }
             Err(e) => Err(e.into()),
             Ok(_) => Ok(true),

--- a/src/rusoto_dynamodbstore.rs
+++ b/src/rusoto_dynamodbstore.rs
@@ -742,7 +742,7 @@ impl super::Backend for Backend {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, fields(consumed_wcu, error.message, otel.status_code, otel.kind = "client"))]
+    #[tracing::instrument(skip_all, fields(consumed_wcu, error.msg, otel.status_code, otel.kind = "client"))]
     async fn exec_atomic_write(&self, op: AtomicWriteOperation<'_>) -> Result<bool> {
         let mut token = Vec::new();
         token.resize(20, 0u8);
@@ -763,7 +763,7 @@ impl super::Backend for Backend {
             .into_iter()
             .map(|op| match op {
                 AtomicWriteSubOperation::Set(key, value) => {
-                    let span = info_span!("set", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("set", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
                     put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
@@ -779,7 +779,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::SetEQ(key, value, old_value, tx) => {
-                    let span = info_span!("set_eq", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("set_eq", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
                     put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
@@ -797,7 +797,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::SetNX(key, value, tx) => {
-                    let span = info_span!("set_nx", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("set_nx", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
                     put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
@@ -814,7 +814,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::Delete(key) => {
-                    let span = info_span!("delete", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("delete", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
                     delete.key = composite_key(&key, NO_SORT_KEY);
@@ -830,7 +830,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::DeleteXX(key, tx) => {
-                    let span = info_span!("delete_xx", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("delete_xx", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
                     delete.key = composite_key(&key, NO_SORT_KEY);
@@ -847,7 +847,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::SAdd(key, value) => {
-                    let span = info_span!("s_add", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("s_add", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut v = AttributeValue::default();
                     v.bs = Some(vec![bytes::Bytes::copy_from_slice(value.as_bytes())]);
                     let mut update = Update::default();
@@ -867,7 +867,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::SRem(key, value) => {
-                    let span = info_span!("s_rem", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("s_rem", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut v = AttributeValue::default();
                     v.bs = Some(vec![bytes::Bytes::copy_from_slice(value.as_bytes())]);
                     let mut update = Update::default();
@@ -887,7 +887,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::ZAdd(key, value, score) => {
-                    let span = info_span!("z_add", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("z_add", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
                     put.item = new_item(
@@ -910,7 +910,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::ZHAdd(key, field, value, score) => {
-                    let span = info_span!("zh_add", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("zh_add", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
                     put.item = new_item(
@@ -933,7 +933,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::ZRem(key, value) => {
-                    let span = info_span!("z_rem", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("z_rem", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
                     delete.key = composite_key(&key, value);
@@ -949,7 +949,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::ZHRem(key, field) => {
-                    let span = info_span!("zh_rem", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("zh_rem", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
                     delete.key = composite_key(&key, field);
@@ -965,7 +965,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::HSet(key, fields) => {
-                    let span = info_span!("h_set", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("h_set", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let (names, values): (HashMap<_, _>, HashMap<_, _>) = fields
                         .into_iter()
                         .enumerate()
@@ -993,7 +993,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::HSetNX(key, field, value, tx) => {
-                    let span = info_span!("h_set_nx", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("h_set_nx", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut update = Update::default();
                     update.table_name = self.table_name.clone();
                     update.key = composite_key(&key, NO_SORT_KEY);
@@ -1015,7 +1015,7 @@ impl super::Backend for Backend {
                     )
                 }
                 AtomicWriteSubOperation::HDel(key, fields) => {
-                    let span = info_span!("h_del", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
+                    let span = info_span!("h_del", ?key, error.msg = Empty, otel.status_code = Empty, otel.kind = "client");
                     let names: HashMap<_, _> = fields
                         .into_iter()
                         .enumerate()
@@ -1050,7 +1050,7 @@ impl super::Backend for Backend {
                     };
                     let state = &states[i];
                     state.span.record("otel.status_code", "ERROR");
-                    state.span.record("error.message", &code);
+                    state.span.record("error.msg", &code);
                     println!("code for {i} is {code:?}");
                     match code {
                         "ConditionalCheckFailed" => {
@@ -1069,13 +1069,13 @@ impl super::Backend for Backend {
                 }
                 let span = Span::current();
                 span.record("otel.status_code", "ERROR");
-                span.record("error.message", "transaction canceled");
+                span.record("error.msg", "transaction canceled");
                 return err.map(Err).unwrap_or(Ok(false));
             }
             Err(e) => {
                 let span = Span::current();
                 span.record("otel.status_code", "ERROR");
-                span.record("error.message", tracing::field::display(&e));
+                span.record("error.msg", tracing::field::display(&e));
                 Err(e.into())
             }
             Ok(r) => {

--- a/src/rusoto_dynamodbstore.rs
+++ b/src/rusoto_dynamodbstore.rs
@@ -29,14 +29,14 @@ fn new_item<'h, 's, S: Into<Arg<'s>> + Send, A: IntoIterator<Item = (&'static st
     attrs: A,
 ) -> HashMap<String, AttributeValue> {
     let mut ret: HashMap<_, _> = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
-    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
+    ret.insert("hk".to_string(), attribute_value(hash.unredacted.as_bytes()));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }
 
 fn composite_key<'k, 's, S: Into<Arg<'s>> + Send>(hash: &ExplicitKey<'k>, sort: S) -> HashMap<String, AttributeValue> {
     let mut ret = HashMap::new();
-    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
+    ret.insert("hk".to_string(), attribute_value(hash.unredacted.as_bytes()));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }

--- a/src/rusoto_dynamodbstore.rs
+++ b/src/rusoto_dynamodbstore.rs
@@ -24,19 +24,19 @@ pub struct Backend {
 const NO_SORT_KEY: &str = "_";
 
 fn new_item<'h, 's, S: Into<Arg<'s>> + Send, A: IntoIterator<Item = (&'static str, AttributeValue)>>(
-    hash: ExplicitKey<'h>,
+    hash: &ExplicitKey<'h>,
     sort: S,
     attrs: A,
 ) -> HashMap<String, AttributeValue> {
     let mut ret: HashMap<_, _> = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
-    ret.insert("hk".to_string(), attribute_value(hash.unredacted));
+    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }
 
-fn composite_key<'k, 's, S: Into<Arg<'s>> + Send>(hash: ExplicitKey<'k>, sort: S) -> HashMap<String, AttributeValue> {
+fn composite_key<'k, 's, S: Into<Arg<'s>> + Send>(hash: &ExplicitKey<'k>, sort: S) -> HashMap<String, AttributeValue> {
     let mut ret = HashMap::new();
-    ret.insert("hk".to_string(), attribute_value(hash.unredacted));
+    ret.insert("hk".to_string(), attribute_value(Arg::Borrowed(hash.unredacted.as_bytes())));
     ret.insert("rk".to_string(), attribute_value(sort));
     ret
 }
@@ -277,7 +277,7 @@ impl Backend {
         let mut put = rusoto_dynamodb::PutItemInput::default();
         put.table_name = self.table_name.clone();
         put.item = new_item(
-            key,
+            &key,
             &field,
             vec![
                 ("v", attribute_value(&value)),
@@ -295,7 +295,7 @@ impl Backend {
         span.record("key", tracing::field::debug(&key));
         let mut delete = rusoto_dynamodb::DeleteItemInput::default();
         delete.table_name = self.table_name.clone();
-        delete.key = composite_key(key.into(), field);
+        delete.key = composite_key(&key, field);
         delete.return_consumed_capacity = Some("TOTAL".to_owned());
         let result = self.client.delete_item(delete).await?;
         record_cap(&result.consumed_capacity, &span);
@@ -352,7 +352,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut get = rusoto_dynamodb::GetItemInput::default();
         get.consistent_read = Some(!self.allow_eventually_consistent_reads);
-        get.key = composite_key(key, NO_SORT_KEY);
+        get.key = composite_key(&key, NO_SORT_KEY);
         get.table_name = self.table_name.clone();
         get.return_consumed_capacity = Some("TOTAL".to_owned());
         let result = self.client.get_item(get).await?;
@@ -367,7 +367,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut put = rusoto_dynamodb::PutItemInput::default();
         put.table_name = self.table_name.clone();
-        put.item = new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
+        put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
         put.return_consumed_capacity = Some("TOTAL".to_owned());
         let result = self.client.put_item(put).await?;
         record_cap(&result.consumed_capacity, &span);
@@ -381,7 +381,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut put = rusoto_dynamodb::PutItemInput::default();
         put.table_name = self.table_name.clone();
-        put.item = new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
+        put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
         put.condition_expression = Some("v = :v".to_string());
         put.expression_attribute_values = Some(vec![(":v".to_string(), attribute_value(old_value))].into_iter().collect());
         put.return_consumed_capacity = Some("TOTAL".to_owned());
@@ -402,7 +402,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut put = rusoto_dynamodb::PutItemInput::default();
         put.table_name = self.table_name.clone();
-        put.item = new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
+        put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
         put.condition_expression = Some("attribute_not_exists(v)".to_string());
         put.return_consumed_capacity = Some("TOTAL".to_owned());
         match self.client.put_item(put).await {
@@ -422,7 +422,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut delete = rusoto_dynamodb::DeleteItemInput::default();
         delete.table_name = self.table_name.clone();
-        delete.key = composite_key(key, NO_SORT_KEY);
+        delete.key = composite_key(&key, NO_SORT_KEY);
         delete.return_values = Some("ALL_OLD".to_string());
         delete.return_consumed_capacity = Some("TOTAL".to_owned());
         let result = self.client.delete_item(delete).await?;
@@ -439,7 +439,7 @@ impl super::Backend for Backend {
         let mut v = AttributeValue::default();
         v.bs = Some(vec![bytes::Bytes::copy_from_slice(value.as_bytes())]);
         let mut update = rusoto_dynamodb::UpdateItemInput::default();
-        update.key = composite_key(key, NO_SORT_KEY);
+        update.key = composite_key(&key, NO_SORT_KEY);
         update.table_name = self.table_name.clone();
         update.update_expression = Some("ADD v :v".to_string());
         update.expression_attribute_values = Some(vec![(":v".to_string(), v)].into_iter().collect());
@@ -456,7 +456,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut get = rusoto_dynamodb::GetItemInput::default();
         get.consistent_read = Some(!self.allow_eventually_consistent_reads);
-        get.key = composite_key(key, NO_SORT_KEY);
+        get.key = composite_key(&key, NO_SORT_KEY);
         get.table_name = self.table_name.clone();
         get.return_consumed_capacity = Some("TOTAL".to_owned());
         let result = self.client.get_item(get).await?;
@@ -477,7 +477,7 @@ impl super::Backend for Backend {
         let mut v = AttributeValue::default();
         v.n = Some(n.to_string());
         let mut update = rusoto_dynamodb::UpdateItemInput::default();
-        update.key = composite_key(key, NO_SORT_KEY);
+        update.key = composite_key(&key, NO_SORT_KEY);
         update.table_name = self.table_name.clone();
         update.update_expression = Some("ADD v :n".to_string());
         update.expression_attribute_values = Some(vec![(":n".to_string(), v)].into_iter().collect());
@@ -511,7 +511,7 @@ impl super::Backend for Backend {
             })
             .unzip();
         let mut update = rusoto_dynamodb::UpdateItemInput::default();
-        update.key = composite_key(key, NO_SORT_KEY);
+        update.key = composite_key(&key, NO_SORT_KEY);
         update.table_name = self.table_name.clone();
         update.update_expression = Some(format!(
             "SET {}",
@@ -536,7 +536,7 @@ impl super::Backend for Backend {
             .map(|(i, f)| (format!("#n{}", i), encode_field_name(f.into().as_bytes())))
             .collect();
         let mut update = rusoto_dynamodb::UpdateItemInput::default();
-        update.key = composite_key(key, NO_SORT_KEY);
+        update.key = composite_key(&key, NO_SORT_KEY);
         update.table_name = self.table_name.clone();
         update.update_expression = Some(format!(
             "REMOVE {}",
@@ -556,7 +556,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut get = rusoto_dynamodb::GetItemInput::default();
         get.consistent_read = Some(!self.allow_eventually_consistent_reads);
-        get.key = composite_key(key.into(), NO_SORT_KEY);
+        get.key = composite_key(&key, NO_SORT_KEY);
         get.table_name = self.table_name.clone();
         get.return_consumed_capacity = Some("TOTAL".to_owned());
         let result = self.client.get_item(get).await?;
@@ -575,7 +575,7 @@ impl super::Backend for Backend {
         span.record("key", tracing::field::debug(&key));
         let mut get = rusoto_dynamodb::GetItemInput::default();
         get.consistent_read = Some(!self.allow_eventually_consistent_reads);
-        get.key = composite_key(key, NO_SORT_KEY);
+        get.key = composite_key(&key, NO_SORT_KEY);
         get.table_name = self.table_name.clone();
         get.return_consumed_capacity = Some("TOTAL".to_owned());
         let result = self.client.get_item(get).await?;
@@ -679,7 +679,7 @@ impl super::Backend for Backend {
             .ops
             .iter()
             .map(|op| match op {
-                BatchSubOperation::Get(key, _) => composite_key(key.clone(), NO_SORT_KEY),
+                BatchSubOperation::Get(key, _) => composite_key(&key, NO_SORT_KEY),
             })
             .collect();
 
@@ -742,14 +742,15 @@ impl super::Backend for Backend {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, err(Display), fields(consumed_wcu))]
+    #[tracing::instrument(skip_all, fields(consumed_wcu, error.message, otel.status_code, otel.kind = "client"))]
     async fn exec_atomic_write(&self, op: AtomicWriteOperation<'_>) -> Result<bool> {
         let mut token = Vec::new();
         token.resize(20, 0u8);
         rand::thread_rng().fill_bytes(&mut token);
         let token = base64::encode_config(token, base64::URL_SAFE_NO_PAD);
 
-        struct SubOpState {
+        struct SubOpState<'a> {
+            key: ExplicitKey<'a>,
             failure_tx: Option<SyncSender<bool>>,
             span: Span,
         }
@@ -762,86 +763,135 @@ impl super::Backend for Backend {
             .into_iter()
             .map(|op| match op {
                 AtomicWriteSubOperation::Set(key, value) => {
-                    let span = info_span!("set", ?key);
+                    let span = info_span!("set", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
-                    put.item = new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
+                    put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
                     let mut item = TransactWriteItem::default();
                     item.put = Some(put);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SetEQ(key, value, old_value, tx) => {
-                    let span = info_span!("set_eq", ?key, condition_failure = Empty);
+                    let span = info_span!("set_eq", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
-                    put.item = new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
+                    put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
                     put.condition_expression = Some("v = :v".to_string());
                     put.expression_attribute_values = Some(vec![(":v".to_string(), attribute_value(old_value))].into_iter().collect());
                     let mut item = TransactWriteItem::default();
                     item.put = Some(put);
-                    (item, SubOpState { failure_tx: Some(tx), span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SetNX(key, value, tx) => {
-                    let span = info_span!("set_nx", ?key, condition_failure = Empty);
+                    let span = info_span!("set_nx", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
-                    put.item = new_item(key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
+                    put.item = new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))]);
                     put.condition_expression = Some("attribute_not_exists(v)".to_string());
                     let mut item = TransactWriteItem::default();
                     item.put = Some(put);
-                    (item, SubOpState { failure_tx: Some(tx), span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::Delete(key) => {
-                    let span = info_span!("delete", ?key);
+                    let span = info_span!("delete", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
-                    delete.key = composite_key(key, NO_SORT_KEY);
+                    delete.key = composite_key(&key, NO_SORT_KEY);
                     let mut item = TransactWriteItem::default();
                     item.delete = Some(delete);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::DeleteXX(key, tx) => {
-                    let span = info_span!("delete_xx", ?key, condition_failure = Empty);
+                    let span = info_span!("delete_xx", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
-                    delete.key = composite_key(key, NO_SORT_KEY);
+                    delete.key = composite_key(&key, NO_SORT_KEY);
                     delete.condition_expression = Some("attribute_exists(v)".to_string());
                     let mut item = TransactWriteItem::default();
                     item.delete = Some(delete);
-                    (item, SubOpState { failure_tx: Some(tx), span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SAdd(key, value) => {
-                    let span = info_span!("s_add", ?key);
+                    let span = info_span!("s_add", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut v = AttributeValue::default();
                     v.bs = Some(vec![bytes::Bytes::copy_from_slice(value.as_bytes())]);
                     let mut update = Update::default();
                     update.table_name = self.table_name.clone();
-                    update.key = composite_key(key, NO_SORT_KEY);
+                    update.key = composite_key(&key, NO_SORT_KEY);
                     update.update_expression = "ADD v :v".to_string();
                     update.expression_attribute_values = Some(vec![(":v".to_string(), v)].into_iter().collect());
                     let mut item = TransactWriteItem::default();
                     item.update = Some(update);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::SRem(key, value) => {
-                    let span = info_span!("s_rem", ?key);
+                    let span = info_span!("s_rem", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut v = AttributeValue::default();
                     v.bs = Some(vec![bytes::Bytes::copy_from_slice(value.as_bytes())]);
                     let mut update = Update::default();
                     update.table_name = self.table_name.clone();
-                    update.key = composite_key(key, NO_SORT_KEY);
+                    update.key = composite_key(&key, NO_SORT_KEY);
                     update.update_expression = "DELETE v :v".to_string();
                     update.expression_attribute_values = Some(vec![(":v".to_string(), v)].into_iter().collect());
                     let mut item = TransactWriteItem::default();
                     item.update = Some(update);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZAdd(key, value, score) => {
-                    let span = info_span!("z_add", ?key);
+                    let span = info_span!("z_add", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
                     put.item = new_item(
-                        key,
+                        &key,
                         &value,
                         vec![
                             ("v", attribute_value(&value)),
@@ -850,14 +900,21 @@ impl super::Backend for Backend {
                     );
                     let mut item = TransactWriteItem::default();
                     item.put = Some(put);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZHAdd(key, field, value, score) => {
-                    let span = info_span!("zh_add", ?key);
+                    let span = info_span!("zh_add", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut put = Put::default();
                     put.table_name = self.table_name.clone();
                     put.item = new_item(
-                        key,
+                        &key,
                         &field,
                         vec![
                             ("v", attribute_value(&value)),
@@ -866,28 +923,49 @@ impl super::Backend for Backend {
                     );
                     let mut item = TransactWriteItem::default();
                     item.put = Some(put);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZRem(key, value) => {
-                    let span = info_span!("z_rem", ?key);
+                    let span = info_span!("z_rem", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
-                    delete.key = composite_key(key, value);
+                    delete.key = composite_key(&key, value);
                     let mut item = TransactWriteItem::default();
                     item.delete = Some(delete);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::ZHRem(key, field) => {
-                    let span = info_span!("zh_rem", ?key);
+                    let span = info_span!("zh_rem", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut delete = Delete::default();
                     delete.table_name = self.table_name.clone();
-                    delete.key = composite_key(key, field);
+                    delete.key = composite_key(&key, field);
                     let mut item = TransactWriteItem::default();
                     item.delete = Some(delete);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::HSet(key, fields) => {
-                    let span = info_span!("h_set", ?key);
+                    let span = info_span!("h_set", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let (names, values): (HashMap<_, _>, HashMap<_, _>) = fields
                         .into_iter()
                         .enumerate()
@@ -899,19 +977,26 @@ impl super::Backend for Backend {
                         .unzip();
                     let mut update = Update::default();
                     update.table_name = self.table_name.clone();
-                    update.key = composite_key(key, NO_SORT_KEY);
+                    update.key = composite_key(&key, NO_SORT_KEY);
                     update.update_expression = format!("SET {}", (0..names.len()).map(|i| format!("#n{} = :n{}", i, i)).collect::<Vec<_>>().join(", "));
                     update.expression_attribute_values = Some(values);
                     update.expression_attribute_names = Some(names);
                     let mut item = TransactWriteItem::default();
                     item.update = Some(update);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::HSetNX(key, field, value, tx) => {
-                    let span = info_span!("h_set_nx", ?key, condition_failure = Empty);
+                    let span = info_span!("h_set_nx", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let mut update = Update::default();
                     update.table_name = self.table_name.clone();
-                    update.key = composite_key(key, NO_SORT_KEY);
+                    update.key = composite_key(&key, NO_SORT_KEY);
                     update.condition_expression = Some("attribute_not_exists(#f)".to_string());
                     update.update_expression = "SET #f = :v".to_string();
                     let mut v = AttributeValue::default();
@@ -920,23 +1005,37 @@ impl super::Backend for Backend {
                     update.expression_attribute_names = Some(vec![("#f".to_string(), encode_field_name(field.as_bytes()))].into_iter().collect());
                     let mut item = TransactWriteItem::default();
                     item.update = Some(update);
-                    (item, SubOpState { failure_tx: Some(tx), span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: Some(tx),
+                            span,
+                        },
+                    )
                 }
                 AtomicWriteSubOperation::HDel(key, fields) => {
-                    let span = info_span!("h_del", ?key);
+                    let span = info_span!("h_del", ?key, error.message = Empty, otel.status_code = Empty, otel.kind = "client");
                     let names: HashMap<_, _> = fields
                         .into_iter()
                         .enumerate()
                         .map(|(i, f)| (format!("#n{}", i), encode_field_name(f.as_bytes())))
                         .collect();
                     let mut update = Update::default();
-                    update.key = composite_key(key, NO_SORT_KEY);
+                    update.key = composite_key(&key, NO_SORT_KEY);
                     update.table_name = self.table_name.clone();
                     update.update_expression = format!("REMOVE {}", (0..names.len()).map(|i| format!("#n{}", i)).collect::<Vec<_>>().join(", "));
                     update.expression_attribute_names = Some(names);
                     let mut item = TransactWriteItem::default();
                     item.update = Some(update);
-                    (item, SubOpState { failure_tx: None, span })
+                    (
+                        item,
+                        SubOpState {
+                            key: key.into_owned(),
+                            failure_tx: None,
+                            span,
+                        },
+                    )
                 }
             })
             .unzip();
@@ -944,30 +1043,41 @@ impl super::Backend for Backend {
 
         match self.client.transact_write_items(tx).await {
             Err(RusotoError::Service(rusoto_dynamodb::TransactWriteItemsError::TransactionCanceled { reasons, .. })) => {
-                let mut did_fail_conditional = false;
-                for (i, reason) in reasons.iter().enumerate() {
-                    if let Some(code) = &reason.code {
-                        if code == "ConditionalCheckFailed" {
-                            did_fail_conditional = true;
-                            let state = &states[i];
-                            state.span.record("condition_failure", true);
+                let mut err = None;
+                for (i, reason) in reasons.into_iter().enumerate() {
+                    let Some(code) = reason.code.as_deref() else {
+                        continue;
+                    };
+                    let state = &states[i];
+                    state.span.record("otel.status_code", "ERROR");
+                    state.span.record("error.message", &code);
+                    println!("code for {i} is {code:?}");
+                    match code {
+                        "ConditionalCheckFailed" => {
                             if let Some(ref tx) = state.failure_tx {
-                                match tx.try_send(true) {
-                                    Ok(_) => {}
-                                    Err(mpsc::TrySendError::Disconnected(_)) => {}
-                                    Err(e) => return Err(e.into()),
-                                }
+                                let _ = tx.try_send(true);
                             }
+                        }
+                        "AtomicWriteConflict" => {
+                            err.get_or_insert_with(|| Error::AtomicWriteConflict(state.key.clone()));
+                        }
+                        "None" => {}
+                        _ => {
+                            err.get_or_insert_with(|| Error::Other(format!("{:?} failed with {}", &state.key, code).into()));
                         }
                     }
                 }
-                if did_fail_conditional {
-                    Ok(false)
-                } else {
-                    Err(Error::AtomicWriteConflict)
-                }
+                let span = Span::current();
+                span.record("otel.status_code", "ERROR");
+                span.record("error.message", "transaction canceled");
+                return err.map(Err).unwrap_or(Ok(false));
             }
-            Err(e) => Err(e.into()),
+            Err(e) => {
+                let span = Span::current();
+                span.record("otel.status_code", "ERROR");
+                span.record("error.message", tracing::field::display(&e));
+                Err(e.into())
+            }
             Ok(r) => {
                 let mut cap = TotalConsumedCapacity::default();
                 for c in r.consumed_capacity.iter().flatten() {

--- a/src/rusoto_dynamodbstore.rs
+++ b/src/rusoto_dynamodbstore.rs
@@ -1051,7 +1051,6 @@ impl super::Backend for Backend {
                     let state = &states[i];
                     state.span.record("otel.status_code", "ERROR");
                     state.span.record("error.msg", &code);
-                    println!("code for {i} is {code:?}");
                     match code {
                         "ConditionalCheckFailed" => {
                             if let Some(ref tx) = state.failure_tx {


### PR DESCRIPTION
* manually attach an `error.message` to subspans (on per-op errors) and to the main span. Unfortunately, `#[tracing(err)]` -> Datadog span export loses the error message (see <https://github.com/tokio-rs/tracing/issues/2648>), so the manual approach is better for now. (Would be nice to have a proc macro that produces the right format but doesn't seem worth it just for keyvaluestore-rs's stuff.)

  (It'd be worthwhile to do the same on other operations, but small steps...)

* also fill in `otel.status_code` and `otel.kind`, which `tracing-opentelemetry` translates to the OpenTelemetry magic, and opentelemetry-datadog passes along. https://github.com/tokio-rs/tracing-opentelemetry/blob/f5f898b47e086659a7a78b495ef77661781895cd/src/layer.rs#L330 https://github.com/open-telemetry/opentelemetry-rust/blob/1f1a4fe0540b5df92b7cf5b289d6e89c2e1c02a8/opentelemetry-datadog/src/exporter/model/v05.rs#L183

* on `AtomicWriteConflict`, mention the offending key.

* if there is an error that isn't a condition failure or write conflict, pass it back to the caller rather than erroneously claiming write conflict.

We could further modify the interface to pass any errors back per-op rather than just condition failure, but I went with the more modest change for now.