### PR TITLE
Add instrumentation to `aws-sdk` `Backend`

### DIFF
--- a/src/aws_sdk_dynamodbstore.rs
+++ b/src/aws_sdk_dynamodbstore.rs
@@ -1,4 +1,4 @@
-use crate::ExplicitKey;
+use crate::{ExplicitKey, ResultExt};
 
 use super::{Arg, AtomicWriteOperation, AtomicWriteSubOperation, BatchOperation, BatchSubOperation, Bound, Error, Key, Result, Value};
 use aws_sdk_dynamodb::{
@@ -6,14 +6,15 @@ use aws_sdk_dynamodb::{
     operation::{put_item::PutItemError, transact_write_items::TransactWriteItemsError},
     primitives::Blob,
     types::{
-        AttributeDefinition, AttributeValue, BillingMode, Delete, KeySchemaElement, KeyType, KeysAndAttributes, LocalSecondaryIndex, Projection,
-        ProjectionType, Put, ReturnValue, ScalarAttributeType, Select, TransactWriteItem, Update,
+        AttributeDefinition, AttributeValue, BillingMode, ConsumedCapacity, Delete, KeySchemaElement, KeyType, KeysAndAttributes, LocalSecondaryIndex,
+        Projection, ProjectionType, Put, ReturnValue, ScalarAttributeType, Select, TransactWriteItem, Update,
     },
 };
 use itertools::Itertools as _;
 use rand::RngCore;
 use simple_error::SimpleError;
 use std::{collections::HashMap, sync::mpsc};
+use tracing::{field::Empty, info_span, Span};
 
 #[derive(Clone)]
 pub struct Backend {
@@ -173,6 +174,11 @@ impl Backend {
         reverse: bool,
         secondary_index: bool,
     ) -> Result<Vec<Value>> {
+        let key = key.into();
+
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let min = map_bound(min, |v| v.into());
         let max = map_bound(max, |v| v.into());
 
@@ -204,7 +210,7 @@ impl Backend {
             if limit > 0 {
                 q = q.limit((limit - members.len() + 1) as _);
             }
-            let result = q.send().await?;
+            let result = q.send().await.spanify_err()?;
             if let Some(mut items) = result.items {
                 let mut skip = 0;
 
@@ -257,101 +263,167 @@ impl Backend {
 
 #[async_trait]
 impl super::Backend for Backend {
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn get<'a, K: Key<'a>>(&self, key: K) -> Result<Option<Value>> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let result = self
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_rcu(&result.consumed_capacity, &span);
+
         Ok(result.item.and_then(|mut item| item.remove("v")).and_then(|v| match v {
             AttributeValue::B(b) => Some(b.into_inner().into()),
             _ => None,
         }))
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn set<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
-        self.client
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
+        let result = self
+            .client
             .put_item()
             .table_name(self.table_name.clone())
-            .set_item(Some(new_item(&key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
+            .set_item(Some(new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_wcu(&result.consumed_capacity, &span);
+
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn set_eq<'a, 'b, 'c, K: Key<'a>, V: Into<Arg<'b>> + Send, OV: Into<Arg<'c>> + Send>(&self, key: K, value: V, old_value: OV) -> Result<bool> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         match self
             .client
             .put_item()
             .table_name(self.table_name.clone())
-            .set_item(Some(new_item(&key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
+            .set_item(Some(new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
             .condition_expression("v = :v")
             .expression_attribute_values(":v", attribute_value(old_value))
             .send()
             .await
             .map_err(|e| e.into_service_error())
         {
-            Ok(_) => Ok(true),
+            Ok(result) => {
+                record_wcu(&result.consumed_capacity, &span);
+
+                Ok(true)
+            }
             Err(PutItemError::ConditionalCheckFailedException(_)) => Ok(false),
             Err(e) => Err(e.into()),
         }
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn set_nx<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<bool> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         match self
             .client
             .put_item()
             .table_name(self.table_name.clone())
-            .set_item(Some(new_item(&key.into(), NO_SORT_KEY, vec![("v", attribute_value(value))])))
+            .set_item(Some(new_item(&key, NO_SORT_KEY, vec![("v", attribute_value(value))])))
             .condition_expression("attribute_not_exists(v)")
             .send()
             .await
             .map_err(|e| e.into_service_error())
         {
-            Ok(_) => Ok(true),
+            Ok(result) => {
+                record_wcu(&result.consumed_capacity, &span);
+
+                Ok(true)
+            }
             Err(PutItemError::ConditionalCheckFailedException(_)) => Ok(false),
             Err(e) => Err(e.into()),
         }
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn delete<'a, K: Key<'a>>(&self, key: K) -> Result<bool> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let result = self
             .client
             .delete_item()
             .table_name(self.table_name.clone())
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .return_values(ReturnValue::AllOld)
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_wcu(&result.consumed_capacity, &span);
+
         Ok(result.attributes.is_some())
     }
 
+    #[tracing::instrument(skip_all, err(Display), fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn s_add<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let value = value.into();
         let v = AttributeValue::Bs(vec![Blob::new(value.into_vec())]);
-        self.client
+
+        let result = self
+            .client
             .update_item()
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression("ADD v :v")
             .expression_attribute_values(":v", v)
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_wcu(&result.consumed_capacity, &span);
+
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn s_members<'a, K: Key<'a>>(&self, key: K) -> Result<Vec<Value>> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let result = self
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_rcu(&result.consumed_capacity, &span);
+
         Ok(result
             .item
             .and_then(|mut item| item.remove("v"))
@@ -362,17 +434,25 @@ impl super::Backend for Backend {
             .unwrap_or(vec![]))
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn n_incr_by<'a, K: Key<'a>>(&self, key: K, n: i64) -> Result<i64> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let output = self
             .client
             .update_item()
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression("ADD v :n")
             .expression_attribute_values(":n", AttributeValue::N(n.to_string()))
             .return_values(ReturnValue::AllNew)
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+        record_wcu(&output.consumed_capacity, &span);
+
         let new_value = output
             .attributes
             .and_then(|mut h| h.remove("v"))
@@ -384,11 +464,16 @@ impl super::Backend for Backend {
         Ok(new_value.parse()?)
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status, error.msg, otel.span_kind = "client"))]
     async fn h_set<'a, 'b, 'c, K: Key<'a>, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send, I: IntoIterator<Item = (F, V)> + Send>(
         &self,
         key: K,
         fields: I,
     ) -> Result<()> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let (names, values): (HashMap<_, _>, HashMap<_, _>) = fields
             .into_iter()
             .enumerate()
@@ -397,9 +482,10 @@ impl super::Backend for Backend {
                 ((format!("#n{}", i), encode_field_name(f.0.into().as_bytes())), (format!(":n{}", i), v))
             })
             .unzip();
-        self.client
+        let result = self
+            .client
             .update_item()
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression(format!(
                 "SET {}",
@@ -408,19 +494,29 @@ impl super::Backend for Backend {
             .set_expression_attribute_values(Some(values))
             .set_expression_attribute_names(Some(names))
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_wcu(&result.consumed_capacity, &span);
+
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn h_del<'a, 'b, K: Key<'a>, F: Into<Arg<'b>> + Send, I: IntoIterator<Item = F> + Send>(&self, key: K, fields: I) -> Result<()> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let names: HashMap<_, _> = fields
             .into_iter()
             .enumerate()
             .map(|(i, f)| (format!("#n{}", i), encode_field_name(f.into().as_bytes())))
             .collect();
-        self.client
+        let result = self
+            .client
             .update_item()
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .update_expression(format!(
                 "REMOVE {}",
@@ -428,19 +524,32 @@ impl super::Backend for Backend {
             ))
             .set_expression_attribute_names(Some(names))
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_wcu(&result.consumed_capacity, &span);
+
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status, error.msg, otel.span_kind = "client"))]
     async fn h_get<'a, 'b, K: Key<'a>, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<Option<Value>> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let result = self
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_rcu(&result.consumed_capacity, &span);
+
         Ok(result
             .item
             .and_then(|mut item| item.remove(&encode_field_name(field.into().as_bytes())))
@@ -450,15 +559,24 @@ impl super::Backend for Backend {
             }))
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn h_get_all<'a, K: Key<'a>>(&self, key: K) -> Result<HashMap<Vec<u8>, Value>> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let result = self
             .client
             .get_item()
             .consistent_read(!self.allow_eventually_consistent_reads)
-            .set_key(Some(composite_key(&key.into(), NO_SORT_KEY)))
+            .set_key(Some(composite_key(&key, NO_SORT_KEY)))
             .table_name(self.table_name.clone())
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_rcu(&result.consumed_capacity, &span);
+
         Ok(result
             .item
             .map(|item| {
@@ -474,19 +592,28 @@ impl super::Backend for Backend {
             .unwrap_or(HashMap::new()))
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
+
     async fn z_add<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V, score: f64) -> Result<()> {
         let v = value.into();
         self.zh_add(key, &v, &v, score).await
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
+
     async fn zh_add<'a, 'b, 'c, K: Key<'a>, F: Into<Arg<'b>> + Send, V: Into<Arg<'c>> + Send>(&self, key: K, field: F, value: V, score: f64) -> Result<()> {
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
         let field = field.into();
         let value = value.into();
-        self.client
+        let result = self
+            .client
             .put_item()
             .table_name(self.table_name.clone())
             .set_item(Some(new_item(
-                &key.into(),
+                &key,
                 &field,
                 vec![
                     ("v", attribute_value(&value)),
@@ -494,23 +621,42 @@ impl super::Backend for Backend {
                 ],
             )))
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_wcu(&result.consumed_capacity, &span);
+
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
+
     async fn zh_rem<'a, 'b, K: Key<'a>, F: Into<Arg<'b>> + Send>(&self, key: K, field: F) -> Result<()> {
-        self.client
+        let key = key.into();
+        let span = tracing::Span::current();
+        span.record("key", tracing::field::debug(&key));
+
+        let result = self
+            .client
             .delete_item()
             .table_name(self.table_name.clone())
-            .set_key(Some(composite_key(&key.into(), field)))
+            .set_key(Some(composite_key(&key, field)))
             .send()
-            .await?;
+            .await
+            .spanify_err()?;
+
+        record_wcu(&result.consumed_capacity, &span);
+
         Ok(())
     }
+
+    #[tracing::instrument(skip_all, fields(key, consumed_wcu, otel.status_code, error.msg, otel.span_kind = "client"))]
 
     async fn z_rem<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
         self.zh_rem(key, value).await
     }
+
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
 
     async fn z_count<'a, K: Key<'a>>(&self, key: K, min: f64, max: f64) -> Result<usize> {
         if min > max {
@@ -533,7 +679,7 @@ impl super::Backend for Backend {
         let mut count = 0;
 
         loop {
-            let result = query.clone().send().await?;
+            let result = query.clone().send().await.spanify_err()?;
             count += result.count as usize;
             match result.last_evaluated_key {
                 Some(key) => query = query.set_exclusive_start_key(Some(key)),
@@ -544,28 +690,37 @@ impl super::Backend for Backend {
         Ok(count)
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
+
     async fn zh_count<'a, K: Key<'a>>(&self, key: K, min: f64, max: f64) -> Result<usize> {
         self.z_count(key, min, max).await
     }
+
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
 
     async fn z_range_by_score<'a, K: Key<'a>>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
         let (min, max) = score_bounds(min, max);
         self.z_range_impl(key, min.into(), max.into(), limit, false, true).await
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
+
     async fn zh_range_by_score<'a, K: Key<'a>>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
         self.z_range_by_score(key, min, max, limit).await
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn z_rev_range_by_score<'a, K: Key<'a>>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
         let (min, max) = score_bounds(min, max);
         self.z_range_impl(key, min.into(), max.into(), limit, true, true).await
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn zh_rev_range_by_score<'a, K: Key<'a>>(&self, key: K, min: f64, max: f64, limit: usize) -> Result<Vec<Value>> {
         self.z_rev_range_by_score(key, min, max, limit).await
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn z_range_by_lex<'a, 'b, 'c, K: Key<'a>, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
         &self,
         key: K,
@@ -577,6 +732,7 @@ impl super::Backend for Backend {
         self.z_range_impl(key, min, max, limit, false, true).await
     }
 
+    #[tracing::instrument(skip_all, fields(key, consistent = !self.allow_eventually_consistent_reads, consumed_rcu, otel.status_code, error.msg, otel.span_kind = "client"))]
     async fn z_rev_range_by_lex<'a, 'b, 'c, K: Key<'a>, M: Into<Arg<'b>> + Send, N: Into<Arg<'c>> + Send>(
         &self,
         key: K,
@@ -588,6 +744,7 @@ impl super::Backend for Backend {
         self.z_range_impl(key, min, max, limit, true, true).await
     }
 
+    #[tracing::instrument(skip_all, fields(consumed_rcu, consistent = !self.allow_eventually_consistent_reads, error.msg, otel.status_code, otel.span_kind = "client"))]
     async fn exec_batch(&self, op: BatchOperation<'_>) -> Result<()> {
         if op.ops.is_empty() {
             return Ok(());
@@ -611,6 +768,7 @@ impl super::Backend for Backend {
 
         const MAX_BATCH_SIZE: usize = 100;
 
+        let mut cap = TotalConsumedCapacity::default();
         while !keys.is_empty() {
             let batch = keys.split_off(if keys.len() > MAX_BATCH_SIZE { keys.len() - MAX_BATCH_SIZE } else { 0 });
             let keys_and_attributes = KeysAndAttributes::builder()
@@ -622,7 +780,12 @@ impl super::Backend for Backend {
                 .batch_get_item()
                 .request_items(self.table_name.clone(), keys_and_attributes)
                 .send()
-                .await?;
+                .await
+                .spanify_err()?;
+
+            for c in result.consumed_capacity.iter().flatten() {
+                cap.add_as_rcu(&c);
+            }
             if let Some(items) = result.responses.and_then(|mut r| r.remove(&self.table_name)) {
                 for mut item in items {
                     if let Some(v) = item.remove("v").and_then(|v| match v {
@@ -651,6 +814,8 @@ impl super::Backend for Backend {
             }
         }
 
+        cap.record_to(&Span::current());
+
         Ok(())
     }
 
@@ -663,6 +828,7 @@ impl super::Backend for Backend {
         struct SubOpState {
             key: ExplicitKey<'static>,
             failure_tx: Option<mpsc::SyncSender<bool>>,
+            span: Span,
         }
 
         let (transact_items, states): (Vec<_>, Vec<_>) = op
@@ -670,6 +836,15 @@ impl super::Backend for Backend {
             .into_iter()
             .map(|op| match op {
                 AtomicWriteSubOperation::Set(key, value) => {
+                    let span = info_span!(
+                        "set",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .put(
                             Put::builder()
@@ -683,10 +858,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::SetEQ(key, value, old_value, tx) => {
+                    let span = info_span!(
+                        "set_eq",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .put(
                             Put::builder()
@@ -702,10 +887,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: Some(tx),
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::SetNX(key, value, tx) => {
+                    let span = info_span!(
+                        "set_nx",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .put(
                             Put::builder()
@@ -720,10 +915,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: Some(tx),
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::Delete(key) => {
+                    let span = info_span!(
+                        "delete",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
@@ -737,10 +942,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::DeleteXX(key, tx) => {
+                    let span = info_span!(
+                        "delete_xx",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
@@ -755,10 +970,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: Some(tx),
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::SAdd(key, value) => {
+                    let span = info_span!(
+                        "s_add",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let v = AttributeValue::Bs(vec![Blob::new(value.into_vec())]);
                     let item = TransactWriteItem::builder()
                         .update(
@@ -775,10 +1000,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::SRem(key, value) => {
+                    let span = info_span!(
+                        "s_rem",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let v = AttributeValue::Bs(vec![Blob::new(value.into_vec())]);
                     let item = TransactWriteItem::builder()
                         .update(
@@ -795,10 +1030,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::ZAdd(key, value, score) => {
+                    let span = info_span!(
+                        "z_add",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .put(
                             Put::builder()
@@ -819,10 +1064,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::ZHAdd(key, field, value, score) => {
+                    let span = info_span!(
+                        "zh_add",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .put(
                             Put::builder()
@@ -843,10 +1098,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::ZRem(key, value) => {
+                    let span = info_span!(
+                        "z_rem",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
@@ -860,10 +1125,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::ZHRem(key, field) => {
+                    let span = info_span!(
+                        "zh_rem",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let item = TransactWriteItem::builder()
                         .delete(
                             Delete::builder()
@@ -877,10 +1152,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::HSet(key, fields) => {
+                    let span = info_span!(
+                        "h_set",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let (names, values): (HashMap<_, _>, HashMap<_, _>) = fields
                         .into_iter()
                         .enumerate()
@@ -908,10 +1193,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::HSetNX(key, field, value, tx) => {
+                    let span = info_span!(
+                        "h_set_nx",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let v = AttributeValue::B(Blob::new(value.into_vec()));
                     let item = TransactWriteItem::builder()
                         .update(
@@ -930,10 +1225,20 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: Some(tx),
+                            span,
                         },
                     ))
                 }
                 AtomicWriteSubOperation::HDel(key, fields) => {
+                    let span = info_span!(
+                        "h_del",
+                        ?key,
+                        error.code = Empty,
+                        error.msg = Empty,
+                        otel.status_code = Empty,
+                        otel.kind = "client"
+                    );
+
                     let names: HashMap<_, _> = fields
                         .into_iter()
                         .enumerate()
@@ -957,6 +1262,7 @@ impl super::Backend for Backend {
                         SubOpState {
                             key: key.into_owned(),
                             failure_tx: None,
+                            span,
                         },
                     ))
                 }
@@ -992,11 +1298,28 @@ impl super::Backend for Backend {
                             err.get_or_insert_with(|| Error::Other(format!("{:?} failed with {}", &state.key, code).into()));
                         }
                     }
+
+                    state.span.record("otel.status_code", "ERROR");
+                    state.span.record("error.code", &code);
+                    if let Some(msg) = &reason.message {
+                        state.span.record("error.msg", msg.clone());
+                    }
                 }
+
+                let span = Span::current();
+                span.record("otel.status_code", "ERROR");
+                span.record("error.msg", "transaction canceled");
                 return err.map(Err).unwrap_or(Ok(false));
             }
             Err(e) => Err(e.into()),
-            Ok(_) => Ok(true),
+            Ok(r) => {
+                let mut cap = TotalConsumedCapacity::default();
+                for c in r.consumed_capacity.iter().flatten() {
+                    cap.add_rcu_and_wcu(&c);
+                }
+                cap.record_to(&Span::current());
+                Ok(true)
+            }
         }
     }
 }
@@ -1035,8 +1358,61 @@ pub async fn create_default_table(client: &Client, table_name: &str) -> Result<(
         .table_name(table_name)
         .billing_mode(BillingMode::PayPerRequest)
         .send()
-        .await?;
+        .await
+        .spanify_err()?;
     Ok(())
+}
+
+/// Tracks total consumed capacity by repeated/batch operations.
+#[derive(Default)]
+struct TotalConsumedCapacity {
+    total_rcu: Option<f64>,
+    total_wcu: Option<f64>,
+}
+
+impl TotalConsumedCapacity {
+    /// Adds individually reported RCU and WCU.
+    ///
+    /// This may be just done for `transact_*`.
+    fn add_rcu_and_wcu(&mut self, c: &ConsumedCapacity) {
+        if let Some(rcu) = c.read_capacity_units {
+            *self.total_rcu.get_or_insert(0.) += rcu;
+        }
+        if let Some(wcu) = c.write_capacity_units {
+            *self.total_wcu.get_or_insert(0.) += wcu;
+        }
+    }
+
+    fn add_as_rcu(&mut self, c: &ConsumedCapacity) {
+        if let Some(rcu) = c.capacity_units {
+            *self.total_rcu.get_or_insert(0.) += rcu;
+        }
+    }
+
+    /// Records to the given span, which must already have empty `consumed_rcu` and `consumed_wcu`
+    /// attributes or recording those will do nothing.
+    fn record_to(&self, span: &Span) {
+        if let Some(rcu) = self.total_rcu {
+            span.record("consumed_rcu", rcu);
+        }
+        if let Some(wcu) = self.total_wcu {
+            span.record("consumed_wcu", wcu);
+        }
+    }
+}
+
+/// Records wcu used by a non-batch write operation to the given span.
+fn record_wcu(capacity: &Option<ConsumedCapacity>, span: &Span) {
+    if let Some(wcu) = capacity.as_ref().and_then(|c| c.capacity_units) {
+        span.record("consumed_wcu", wcu);
+    }
+}
+
+/// Records rcu used by a non-batch read operation to the given span.
+fn record_rcu(capacity: &Option<ConsumedCapacity>, span: &Span) {
+    if let Some(rcu) = capacity.as_ref().and_then(|c| c.capacity_units) {
+        span.record("consumed_rcu", rcu);
+    }
 }
 
 #[cfg(test)]
@@ -1066,13 +1442,7 @@ mod test {
 
             if let Ok(_) = client.delete_table().table_name(table_name).send().await {
                 for _ in 0..10u32 {
-                    match client
-                        .describe_table()
-                        .table_name(table_name.clone())
-                        .send()
-                        .await
-                        .map_err(|e| e.into_service_error())
-                    {
+                    match client.describe_table().table_name(table_name).send().await.map_err(|e| e.into_service_error()) {
                         Err(DescribeTableError::ResourceNotFoundException(_)) => break,
                         _ => time::sleep(time::Duration::from_millis(200)).await,
                     }

--- a/src/rusoto_dynamodbstore.rs
+++ b/src/rusoto_dynamodbstore.rs
@@ -1188,55 +1188,6 @@ impl super::Backend for Backend {
     }
 }
 
-pub async fn create_default_table(client: &DynamoDbClient, table_name: &str) -> Result<()> {
-    let mut create = rusoto_dynamodb::CreateTableInput::default();
-    create.attribute_definitions = vec![
-        AttributeDefinition {
-            attribute_name: "hk".to_string(),
-            attribute_type: "B".to_string(),
-        },
-        AttributeDefinition {
-            attribute_name: "rk".to_string(),
-            attribute_type: "B".to_string(),
-        },
-        AttributeDefinition {
-            attribute_name: "rk2".to_string(),
-            attribute_type: "B".to_string(),
-        },
-    ];
-    create.key_schema = vec![
-        KeySchemaElement {
-            attribute_name: "hk".to_string(),
-            key_type: "HASH".to_string(),
-        },
-        KeySchemaElement {
-            attribute_name: "rk".to_string(),
-            key_type: "RANGE".to_string(),
-        },
-    ];
-    create.local_secondary_indexes = Some(vec![LocalSecondaryIndex {
-        index_name: "rk2".to_string(),
-        key_schema: vec![
-            KeySchemaElement {
-                attribute_name: "hk".to_string(),
-                key_type: "HASH".to_string(),
-            },
-            KeySchemaElement {
-                attribute_name: "rk2".to_string(),
-                key_type: "RANGE".to_string(),
-            },
-        ],
-        projection: Projection {
-            non_key_attributes: None,
-            projection_type: Some("ALL".to_string()),
-        },
-    }]);
-    create.table_name = table_name.to_string();
-    create.billing_mode = Some("PAY_PER_REQUEST".to_string());
-    client.create_table(create).await?;
-    Ok(())
-}
-
 /// Tracks total consumed capacity by repeated/batch operations.
 #[derive(Default)]
 struct TotalConsumedCapacity {
@@ -1287,6 +1238,55 @@ fn record_rcu(capacity: &Option<ConsumedCapacity>, span: &Span) {
     if let Some(rcu) = capacity.as_ref().and_then(|c| c.capacity_units) {
         span.record("consumed_rcu", rcu);
     }
+}
+
+pub async fn create_default_table(client: &DynamoDbClient, table_name: &str) -> Result<()> {
+    let mut create = rusoto_dynamodb::CreateTableInput::default();
+    create.attribute_definitions = vec![
+        AttributeDefinition {
+            attribute_name: "hk".to_string(),
+            attribute_type: "B".to_string(),
+        },
+        AttributeDefinition {
+            attribute_name: "rk".to_string(),
+            attribute_type: "B".to_string(),
+        },
+        AttributeDefinition {
+            attribute_name: "rk2".to_string(),
+            attribute_type: "B".to_string(),
+        },
+    ];
+    create.key_schema = vec![
+        KeySchemaElement {
+            attribute_name: "hk".to_string(),
+            key_type: "HASH".to_string(),
+        },
+        KeySchemaElement {
+            attribute_name: "rk".to_string(),
+            key_type: "RANGE".to_string(),
+        },
+    ];
+    create.local_secondary_indexes = Some(vec![LocalSecondaryIndex {
+        index_name: "rk2".to_string(),
+        key_schema: vec![
+            KeySchemaElement {
+                attribute_name: "hk".to_string(),
+                key_type: "HASH".to_string(),
+            },
+            KeySchemaElement {
+                attribute_name: "rk2".to_string(),
+                key_type: "RANGE".to_string(),
+            },
+        ],
+        projection: Projection {
+            non_key_attributes: None,
+            projection_type: Some("ALL".to_string()),
+        },
+    }]);
+    create.table_name = table_name.to_string();
+    create.billing_mode = Some("PAY_PER_REQUEST".to_string());
+    client.create_table(create).await?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/rusoto_dynamodbstore.rs
+++ b/src/rusoto_dynamodbstore.rs
@@ -14,6 +14,17 @@ use std::{
 };
 use tracing::{field::Empty, info_span, Span};
 
+trait ErrExt {
+    fn spanify(self) -> Self;
+}
+
+impl<E: std::error::Error + Sync + Send + 'static> ErrExt for E {
+    fn spanify(self) -> Self {
+        crate::add_err_to_span(&self);
+        self
+    }
+}
+
 #[derive(Clone)]
 pub struct Backend {
     pub allow_eventually_consistent_reads: bool,
@@ -1275,17 +1286,6 @@ fn record_wcu(capacity: &Option<ConsumedCapacity>, span: &Span) {
 fn record_rcu(capacity: &Option<ConsumedCapacity>, span: &Span) {
     if let Some(rcu) = capacity.as_ref().and_then(|c| c.capacity_units) {
         span.record("consumed_rcu", rcu);
-    }
-}
-
-trait ErrExt {
-    fn spanify(self) -> Self;
-}
-
-impl<E: std::error::Error + Sync + Send + 'static> ErrExt for E {
-    fn spanify(self) -> Self {
-        crate::add_err_to_span(&self);
-        self
     }
 }
 


### PR DESCRIPTION
- Refactored shared instrumentation code into `lib.rs`

The `aws-sdk` instrumentation is now equivalent with the `rusoto` instrumentation as far as I can tell.