### PR TITLE
unbreak CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ on: [push]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Test
       run: |
-        docker-compose run dev cargo test --all-features
+        docker compose run dev cargo test --all-features


### PR DESCRIPTION
* newer Ubuntu images use `docker compose`, not `docker-compose`
* pin an Ubuntu version (the newest Ubuntu, for once!)
* while here, use a non-deprecated version of actions/checkout