### PR TITLE
allow efficiently getting key back from GetResult

### DIFF
--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -444,7 +444,7 @@ macro_rules! test_backend {
             let get = batch.get("foo");
             b.exec_batch(batch).await.unwrap();
 
-            assert_eq!(get.value(), Some("bar".into()));
+            assert_eq!(get.into_parts().1, Some("bar".into()));
 
             let mut batch = BatchOperation::new();
             let get = batch.get("foo");
@@ -452,9 +452,9 @@ macro_rules! test_backend {
             let get3 = batch.get("foo3");
             b.exec_batch(batch).await.unwrap();
 
-            assert_eq!(get.value(), Some("bar".into()));
-            assert_eq!(get2.value(), Some("bar2".into()));
-            assert_eq!(get3.value(), None);
+            assert_eq!(get.into_parts().1, Some("bar".into()));
+            assert_eq!(get2.into_parts().1, Some("bar2".into()));
+            assert_eq!(get3.into_parts().1, None);
         }
 
         #[tokio::test]

--- a/src/dynstore.rs
+++ b/src/dynstore.rs
@@ -145,7 +145,7 @@ impl super::Backend for Backend {
         dispatch!(self, backend, { backend.z_rev_range_by_lex(key, min, max, limit) })
     }
 
-    async fn exec_batch(&self, op: BatchOperation<'_>) -> Result<()> {
+    async fn exec_batch(&self, op: BatchOperation) -> Result<()> {
         dispatch!(self, backend, { backend.exec_batch(op) })
     }
 

--- a/src/readcache.rs
+++ b/src/readcache.rs
@@ -297,8 +297,7 @@ impl<B: super::Backend + Send + Sync> super::Backend for Backend<B> {
             match self.inner.exec_batch(op).await {
                 Ok(_) => {
                     for get in gets {
-                        let l = get.value.lock().expect("GetInner should not be poisoned");
-                        self.store(get.key.unredacted.as_bytes().into(), Entry::Get(l.clone()));
+                        self.store(get.key.unredacted.as_bytes().into(), Entry::Get(get.value.get().cloned()));
                     }
                     Ok(())
                 }


### PR DESCRIPTION
...to make it easier for calling deserialization code to embed the key in errors. The caller could have kept the key around independently or regenerated it in the error path, but this seems a lot more pleasant for the batch get case.

* Avoid the need to clone the key passed to `key::unredacted` by altering the definition of `ExplicitKey`.
* just return `ExplicitKey` from `unredacted_key` so it's `Clone`.
* keep the key around and expose it from `GetResult`. This also changes the way the result transmission is done to simplify and share the `Arc` with the key.