### PR TITLE
add missing s_rem helper, amongst other things.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,10 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Test
-      run: |
-        docker compose run dev cargo test --all-features
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Test
+        run: |
+          docker compose run dev cargo test --all-features
+          docker compose run dev cargo test --no-default-features
+          docker compose run dev cargo test --no-default-features --features redis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Test
         run: |
+          docker compose run dev cargo clippy --all-features -- -D warnings
+          docker compose run dev cargo clippy --no-default-features -- -D warnings
+          docker compose run dev cargo clippy --no-default-features --features redis -- -D warnings
+
           docker compose run dev cargo test --all-features
-          docker compose run dev cargo test --no-default-features
-          docker compose run dev cargo test --no-default-features --features redis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM rust:1.87
+RUN rustup component add clippy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # keyvaluestore-rs
 
+You can find rustdocs for the master branch of this repo at https://sportsball-ai.github.io/keyvaluestore-rs/keyvaluestore/
+
 Like [ccbrown/keyvaluestore](https://github.com/ccbrown/keyvaluestore) but for Rust.
 
 Abstracts a key-value store interface over AWS DynamoDB, Redis, and in-memory. Allows dynamic backend selection, and provides a read cache wrapper for these backends.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # keyvaluestore-rs
 
 Like [ccbrown/keyvaluestore](https://github.com/ccbrown/keyvaluestore) but for Rust.
+
+Abstracts a key-value store interface over AWS DynamoDB, Redis, and in-memory. Allows dynamic backend selection, and provides a read cache wrapper for these backends.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   dev:
-    image: rust:1.70
+    build: .
     environment:
       DYNAMODB_ENDPOINT: http://dynamodb.local:8000
       REDIS_ADDRESS: redis.local:6379

--- a/src/aws_sdk_dynamodbstore.rs
+++ b/src/aws_sdk_dynamodbstore.rs
@@ -87,11 +87,11 @@ impl<'a> ArgBound<'a> {
     }
 }
 
-impl<'a> Into<Bound<Arg<'a>>> for ArgBound<'a> {
-    fn into(self) -> Bound<Arg<'a>> {
-        match self {
-            Self::Inclusive(a) => Bound::Included(a),
-            Self::Unbounded => Bound::Unbounded,
+impl<'a> From<ArgBound<'a>> for Bound<Arg<'a>> {
+    fn from(val: ArgBound<'a>) -> Self {
+        match val {
+            ArgBound::<'a>::Inclusive(a) => Bound::Included(a),
+            ArgBound::<'a>::Unbounded => Bound::Unbounded,
         }
     }
 }
@@ -156,9 +156,9 @@ fn encode_field_name(name: &[u8]) -> String {
     "~".to_string() + &base64::encode_config(name, base64::URL_SAFE_NO_PAD)
 }
 
-fn decode_field_name(name: &String) -> Option<Vec<u8>> {
-    if name.starts_with('~') {
-        base64::decode_config(&name[1..], base64::URL_SAFE_NO_PAD).ok()
+fn decode_field_name(name: &str) -> Option<Vec<u8>> {
+    if let Some(no_prefix_name) = name.strip_prefix('~') {
+        base64::decode_config(no_prefix_name, base64::URL_SAFE_NO_PAD).ok()
     } else {
         None
     }
@@ -191,7 +191,7 @@ impl Backend {
             }
         }
 
-        let (condition, attribute_values) = query_condition(key.into(), inclusive_min, inclusive_max, secondary_index);
+        let (condition, attribute_values) = query_condition(key, inclusive_min, inclusive_max, secondary_index);
 
         let mut query = self
             .client
@@ -276,7 +276,6 @@ impl Backend {
         value: V,
         score: f64,
     ) -> Result<()> {
-        let key = key.into();
         let span = tracing::Span::current();
         span.record("key", tracing::field::debug(&key));
 
@@ -291,7 +290,7 @@ impl Backend {
                 &field,
                 vec![
                     ("v", attribute_value(&value)),
-                    ("rk2", attribute_value(&[&float_sort_key(score), field.as_bytes()].concat())),
+                    ("rk2", attribute_value([&float_sort_key(score), field.as_bytes()].concat())),
                 ],
             )))
             .return_consumed_capacity(ReturnConsumedCapacity::Total)
@@ -332,7 +331,7 @@ impl Backend {
         span.record("key", tracing::field::debug(&key));
 
         let (min, max) = score_bounds(min, max);
-        let (condition, attribute_values) = query_condition(key.into(), min, max, true);
+        let (condition, attribute_values) = query_condition(key, min, max, true);
 
         let mut query = self
             .client
@@ -851,7 +850,7 @@ impl super::Backend for Backend {
                 .spanify_err()?;
 
             for c in result.consumed_capacity.iter().flatten() {
-                cap.add_as_rcu(&c);
+                cap.add_as_rcu(c);
             }
             if let Some(items) = result.responses.and_then(|mut r| r.remove(&self.table_name)) {
                 for mut item in items {
@@ -880,8 +879,7 @@ impl super::Backend for Backend {
     }
 
     async fn exec_atomic_write(&self, op: AtomicWriteOperation<'_>) -> Result<bool> {
-        let mut token = Vec::new();
-        token.resize(20, 0u8);
+        let mut token = vec![0; 20];
         rand::thread_rng().fill_bytes(&mut token);
         let token = base64::encode_config(token, base64::URL_SAFE_NO_PAD);
 
@@ -1113,7 +1111,7 @@ impl super::Backend for Backend {
                                     &value,
                                     vec![
                                         ("v", attribute_value(&value)),
-                                        ("rk2", attribute_value(&[&float_sort_key(score), value.as_bytes()].concat())),
+                                        ("rk2", attribute_value([&float_sort_key(score), value.as_bytes()].concat())),
                                     ],
                                 )))
                                 .build()?,
@@ -1147,7 +1145,7 @@ impl super::Backend for Backend {
                                     &field,
                                     vec![
                                         ("v", attribute_value(&value)),
-                                        ("rk2", attribute_value(&[&float_sort_key(score), field.as_bytes()].concat())),
+                                        ("rk2", attribute_value([&float_sort_key(score), field.as_bytes()].concat())),
                                     ],
                                 )))
                                 .build()?,
@@ -1361,7 +1359,7 @@ impl super::Backend for Backend {
                     }
 
                     state.span.record("otel.status_code", "ERROR");
-                    state.span.record("error.code", &code);
+                    state.span.record("error.code", code);
                     if let Some(msg) = &reason.message {
                         state.span.record("error.msg", msg.clone());
                     }
@@ -1376,7 +1374,7 @@ impl super::Backend for Backend {
             Ok(r) => {
                 let mut cap = TotalConsumedCapacity::default();
                 for c in r.consumed_capacity.iter().flatten() {
-                    cap.add_rcu_and_wcu(&c);
+                    cap.add_rcu_and_wcu(c);
                 }
                 cap.record_to(&Span::current());
                 Ok(true)
@@ -1501,7 +1499,7 @@ mod test {
 
             let table_name = "BackendTest";
 
-            if let Ok(_) = client.delete_table().table_name(table_name).send().await {
+            if client.delete_table().table_name(table_name).send().await.is_ok() {
                 for _ in 0..10u32 {
                     match client.describe_table().table_name(table_name).send().await.map_err(|e| e.into_service_error()) {
                         Err(DescribeTableError::ResourceNotFoundException(_)) => break,
@@ -1510,7 +1508,7 @@ mod test {
                 }
             }
 
-            aws_sdk_dynamodbstore::create_default_table(&client, &table_name)
+            aws_sdk_dynamodbstore::create_default_table(&client, table_name)
                 .await
                 .expect("failed to create table");
 

--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -68,6 +68,26 @@ macro_rules! test_backend {
 
         #[tokio::test]
         #[serial]
+        async fn test_s_rem() {
+            let b = ($f)().await;
+
+            b.s_add("foo", "bar").await.unwrap();
+            b.s_add("foo", "baz").await.unwrap();
+            b.s_add("foo", "zam").await.unwrap();
+            b.s_rem("foo", "bar").await.unwrap();
+            let mut members = b.s_members("foo").await.unwrap();
+            members.sort();
+            assert_eq!(vec!["baz", "zam"], members);
+            b.s_rem("foo", "baz").await.unwrap();
+            let members = b.s_members("foo").await.unwrap();
+            assert_eq!(vec!["zam"], members);
+            b.s_rem("foo", "zam").await.unwrap();
+            let members = b.s_members("foo").await.unwrap();
+            assert!(members.is_empty());
+        }
+
+        #[tokio::test]
+        #[serial]
         async fn test_n_incr_by() {
             let b = ($f)().await;
 

--- a/src/backendtest.rs
+++ b/src/backendtest.rs
@@ -1,8 +1,8 @@
 #[macro_export]
 macro_rules! test_backend {
     ($f:expr) => {
-        use crate::{AtomicWriteOperation, Backend, BatchOperation};
         use std::ops::Bound;
+        use $crate::{AtomicWriteOperation, Backend, BatchOperation};
 
         #[tokio::test]
         #[serial]
@@ -414,7 +414,7 @@ macro_rules! test_backend {
 
             // DynamoDB has to paginate requests for z_counts on big sets.
             let mut big_value = Vec::new();
-            big_value.resize(1000, 'x' as u8);
+            big_value.resize(1000, b'x');
             for i in 0..1100 {
                 b.z_add("big", [i.to_string().as_bytes().to_vec(), big_value.clone()].concat(), 0.0)
                     .await
@@ -443,7 +443,7 @@ macro_rules! test_backend {
 
             // DynamoDB has to paginate requests for zh_counts on big sets.
             let mut big_value = Vec::new();
-            big_value.resize(1000, 'x' as u8);
+            big_value.resize(1000, b'x');
             for i in 0..1100 {
                 b.z_add("big", [i.to_string().as_bytes().to_vec(), big_value.clone()].concat(), 0.0)
                     .await

--- a/src/dynstore.rs
+++ b/src/dynstore.rs
@@ -57,6 +57,10 @@ impl super::Backend for Backend {
         dispatch!(self, backend, { backend.s_add(key, value) })
     }
 
+    async fn s_rem<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+        dispatch!(self, backend, { backend.s_rem(key, value) })
+    }
+
     async fn s_members<'a, K: Key<'a>>(&self, key: K) -> Result<Vec<Value>> {
         dispatch!(self, backend, { backend.s_members(key) })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,7 @@ pub trait Backend {
     async fn delete<'a, K: Key<'a>>(&self, key: K) -> Result<bool>;
 
     async fn s_add<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()>;
+    async fn s_rem<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()>;
     async fn s_members<'a, K: Key<'a>>(&self, key: K) -> Result<Vec<Value>>;
 
     /// Increments the number with the given key by some number, returning the new value. If the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,6 @@ pub mod readcache;
 #[cfg(feature = "redis")]
 pub mod redisstore;
 
-use tracing::Span;
-
 #[derive(Debug)]
 pub enum Error {
     // AtomicWriteConflict happens when an atomic write fails due to contention (but not due to a
@@ -146,7 +144,7 @@ pub enum Arg<'a> {
 impl<'a> Arg<'a> {
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            Self::Owned(v) => &v,
+            Self::Owned(v) => v,
             Self::Borrowed(v) => v,
         }
     }
@@ -173,45 +171,45 @@ impl<'a> Arg<'a> {
     }
 }
 
-impl Into<Arg<'static>> for Vec<u8> {
-    fn into(self) -> Arg<'static> {
-        Arg::Owned(self)
+impl From<Vec<u8>> for Arg<'static> {
+    fn from(val: Vec<u8>) -> Self {
+        Arg::Owned(val)
     }
 }
 
-impl<'a> Into<Arg<'a>> for &'a Arg<'a> {
-    fn into(self) -> Arg<'a> {
-        Arg::Borrowed(self.as_bytes())
+impl<'a> From<&'a Arg<'a>> for Arg<'a> {
+    fn from(val: &'a Arg<'a>) -> Self {
+        Arg::Borrowed(val.as_bytes())
     }
 }
 
-impl<'a> Into<Arg<'a>> for &'a Vec<u8> {
-    fn into(self) -> Arg<'a> {
-        Arg::Borrowed(&self)
+impl<'a> From<&'a Vec<u8>> for Arg<'a> {
+    fn from(val: &'a Vec<u8>) -> Self {
+        Arg::Borrowed(val)
     }
 }
 
-impl<'a> Into<Arg<'a>> for &'a [u8] {
-    fn into(self) -> Arg<'a> {
-        Arg::Borrowed(self)
+impl<'a> From<&'a [u8]> for Arg<'a> {
+    fn from(val: &'a [u8]) -> Self {
+        Arg::Borrowed(val)
     }
 }
 
-impl<'a> Into<Arg<'a>> for &'a str {
-    fn into(self) -> Arg<'a> {
-        Arg::Borrowed(self.as_bytes())
+impl<'a> From<&'a str> for Arg<'a> {
+    fn from(val: &'a str) -> Self {
+        Arg::Borrowed(val.as_bytes())
     }
 }
 
-impl Into<Arg<'static>> for String {
-    fn into(self) -> Arg<'static> {
-        Arg::Owned(self.into_bytes())
+impl From<String> for Arg<'static> {
+    fn from(val: String) -> Self {
+        Arg::Owned(val.into_bytes())
     }
 }
 
-impl<'a> Into<Arg<'a>> for &'a String {
-    fn into(self) -> Arg<'a> {
-        Arg::Borrowed(self.as_bytes())
+impl<'a> From<&'a String> for Arg<'a> {
+    fn from(val: &'a String) -> Self {
+        Arg::Borrowed(val.as_bytes())
     }
 }
 
@@ -367,13 +365,14 @@ pub enum BatchSubOperation {
 
 pub struct BatchGet(Arc<GetInner>);
 
+#[derive(Default)]
 pub struct BatchOperation {
     pub ops: Vec<BatchSubOperation>,
 }
 
 impl BatchOperation {
     pub fn new() -> Self {
-        Self { ops: vec![] }
+        Self::default()
     }
 
     pub fn get<K: Key<'static>>(&mut self, key: K) -> GetResult {
@@ -419,13 +418,14 @@ pub enum AtomicWriteSubOperation<'a> {
 // limit.
 pub const MAX_ATOMIC_WRITE_SUB_OPERATIONS: usize = 25;
 
+#[derive(Default)]
 pub struct AtomicWriteOperation<'a> {
     pub ops: Vec<AtomicWriteSubOperation<'a>>,
 }
 
 impl<'a> AtomicWriteOperation<'a> {
     pub fn new() -> Self {
-        Self { ops: vec![] }
+        Self::default()
     }
 
     pub fn set<'k: 'a, 'v: 'a, K: Key<'k>, V: Into<Arg<'v>> + Send>(&mut self, key: K, value: V) {
@@ -511,16 +511,19 @@ impl<'a> AtomicWriteOperation<'a> {
     }
 }
 
+#[cfg(feature = "aws-sdk")]
 pub(crate) fn add_err_to_span(e: &(dyn std::error::Error + Sync + Send + 'static)) {
-    let span = Span::current();
+    let span = tracing::Span::current();
     span.record("otel.status_code", "ERROR");
     span.record("error.msg", e);
 }
 
+#[cfg(feature = "aws-sdk")]
 pub(crate) trait ResultExt {
     fn spanify_err(self) -> Self;
 }
 
+#[cfg(feature = "aws-sdk")]
 impl<T, E: std::error::Error + Sync + Send + 'static> ResultExt for std::result::Result<T, E> {
     fn spanify_err(self) -> Self {
         if let Err(ref e) = self {

--- a/src/memorystore.rs
+++ b/src/memorystore.rs
@@ -258,6 +258,11 @@ impl super::Backend for Backend {
         Self::s_add(&mut m, key.into(), value)
     }
 
+    async fn s_rem<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+        let mut m = self.m.lock().unwrap();
+        Self::s_rem(&mut m, key.into(), value)
+    }
+
     async fn s_members<'a, K: Key<'a>>(&self, key: K) -> Result<Vec<Value>> {
         let m = self.m.lock().unwrap();
         let key = key.into();

--- a/src/readcache.rs
+++ b/src/readcache.rs
@@ -115,6 +115,13 @@ impl<B: super::Backend + Send + Sync> super::Backend for Backend<B> {
         r
     }
 
+    async fn s_rem<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+        let key = key.into();
+        let r = self.inner.s_rem(&key, value).await;
+        self.invalidate(key.unredacted.as_bytes());
+        r
+    }
+
     async fn s_members<'a, K: Key<'a>>(&self, key: K) -> Result<Vec<Value>> {
         let key = key.into();
         match self.load(&key.unredacted) {

--- a/src/redisstore.rs
+++ b/src/redisstore.rs
@@ -127,6 +127,10 @@ impl super::Backend for Backend {
         Ok(self.get_connection().await?.sadd(key.into(), value.into()).await?)
     }
 
+    async fn s_rem<'a, 'b, K: Key<'a>, V: Into<Arg<'b>> + Send>(&self, key: K, value: V) -> Result<()> {
+        Ok(self.get_connection().await?.srem(key.into(), value.into()).await?)
+    }
+
     async fn s_members<'a, K: Key<'a>>(&self, key: K) -> Result<Vec<Value>> {
         Ok(self.get_connection().await?.smembers(key.into()).await?)
     }


### PR DESCRIPTION
I noticed that the s_rem helper was missing from the backend trait, so I added it. Then I found some other things that seemed easy to fix so I fixed them.

- CI now runs clippy for all possible feature configurations
- Add unit tests for new s_rem helper
- Fixed many clippy warnings
- README explains the purpose a bit better
- README now links to rustdocs which are generated and published thanks to 3ab0c4e435d95fe21ba3b5886e439789cb14ba93 and 5ebf246f7a36bb61f916e78562ab641766568865